### PR TITLE
Feature/fix GitHub repo file race condition

### DIFF
--- a/modules/aks/github-connector/buildingblock/APP_TEAM_README.md
+++ b/modules/aks/github-connector/buildingblock/APP_TEAM_README.md
@@ -10,6 +10,9 @@ This building block is for application teams that want to automate deployments t
 - A development team pushes new code to GitHub, triggering an automated pipeline that builds a Docker image, pushes it to Azure Container Registry (ACR), and deploys it to AKS.
 - A DevOps team sets up GitHub Actions workflows to run security scans and compliance checks before deploying applications to AKS.
 
+## Prerequisites
+- A `Dockerfile` must be present in the used repository, as the GitHub Actions workflow will deploy this `Dockerfile`.
+
 ## Shared Responsibility
 
 | Responsibility          | Platform Team | Application Team |

--- a/modules/aks/github-connector/buildingblock/README.md
+++ b/modules/aks/github-connector/buildingblock/README.md
@@ -57,8 +57,6 @@ No modules.
 | [github_actions_environment_secret.kubeconfig](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/actions_environment_secret) | resource |
 | [github_branch.custom_branch](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/branch) | resource |
 | [github_repository_environment.env](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/repository_environment) | resource |
-| [github_repository_file.dockerfile](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/repository_file) | resource |
-| [github_repository_file.readme](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/repository_file) | resource |
 | [github_repository_file.workflow](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/repository_file) | resource |
 | [kubernetes_role.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/role) | resource |
 | [kubernetes_role_binding.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/role_binding) | resource |
@@ -72,7 +70,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_branch"></a> [branch](#input\_branch) | Branch to use for deployments. If not provided, defaults to 'main'. If a custom branch is provided, it will be created if it doesn't exist. | `string` | `"main"` | no |
 | <a name="input_github_repo"></a> [github\_repo](#input\_github\_repo) | n/a | `string` | n/a | yes |
-| <a name="input_init_shared_files"></a> [init\_shared\_files](#input\_init\_shared\_files) | Whether to initialize shared files (README.md and Dockerfile) in the repository | `bool` | `true` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Associated namespace in AKS. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/aks/github-connector/buildingblock/README.md
+++ b/modules/aks/github-connector/buildingblock/README.md
@@ -65,9 +65,6 @@ No modules.
 | [kubernetes_secret.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
 | [kubernetes_secret.image_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
 | [kubernetes_service_account.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/service_account) | resource |
-| [time_sleep.after_dockerfile](https://registry.terraform.io/providers/hashicorp/time/0.11.1/docs/resources/sleep) | resource |
-| [time_sleep.after_readme](https://registry.terraform.io/providers/hashicorp/time/0.11.1/docs/resources/sleep) | resource |
-| [time_sleep.after_workflow](https://registry.terraform.io/providers/hashicorp/time/0.11.1/docs/resources/sleep) | resource |
 
 ## Inputs
 
@@ -75,6 +72,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_branch"></a> [branch](#input\_branch) | Branch to use for deployments. If not provided, defaults to 'main'. If a custom branch is provided, it will be created if it doesn't exist. | `string` | `"main"` | no |
 | <a name="input_github_repo"></a> [github\_repo](#input\_github\_repo) | n/a | `string` | n/a | yes |
+| <a name="input_init_shared_files"></a> [init\_shared\_files](#input\_init\_shared\_files) | Whether to initialize shared files (README.md and Dockerfile) in the repository | `bool` | `true` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Associated namespace in AKS. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/aks/github-connector/buildingblock/github.tf
+++ b/modules/aks/github-connector/buildingblock/github.tf
@@ -56,46 +56,6 @@ resource "github_actions_environment_secret" "container_registry" {
   ]
 }
 
-resource "github_repository_file" "readme" {
-  count      = var.init_shared_files ? 1 : 0
-  repository = github_repository_environment.env.repository
-
-  file = "README.md"
-  content = templatefile(
-    "${path.module}/repo_content/README.MD",
-    {
-      github_repo = var.github_repo
-    }
-  )
-
-  commit_message      = "README for GitHub actions setup"
-  overwrite_on_create = true
-
-  lifecycle {
-    ignore_changes = [content]
-  }
-}
-
-resource "github_repository_file" "dockerfile" {
-  count      = var.init_shared_files ? 1 : 0
-  repository = github_repository_environment.env.repository
-
-  file    = "Dockerfile"
-  content = file("${path.module}/repo_content/Dockerfile")
-
-  commit_message      = "Basic Dockerfile"
-  overwrite_on_create = true
-
-  depends_on = [
-    github_repository_environment.env, # ensure environment exists first
-    github_repository_file.readme      # make sure files are created sequentially
-  ]
-
-  lifecycle {
-    ignore_changes = [content]
-  }
-}
-
 resource "github_repository_file" "workflow" {
   repository = github_repository_environment.env.repository
 
@@ -116,7 +76,6 @@ resource "github_repository_file" "workflow" {
 
   depends_on = [
     kubernetes_role_binding.github_actions, # workflow needs role binding to deploy
-    github_repository_file.dockerfile       # workflow requires dockerfile to be present
   ]
 
   lifecycle {
@@ -131,6 +90,6 @@ resource "github_branch" "custom_branch" {
   branch     = var.branch
 
   depends_on = [
-    github_repository_file.workflow # ensure all files are created before branch, so all data is also available on the custom branch
+    github_repository_file.workflow # ensure workflow file is created before branch, so all data is also available on the custom branch
   ]
 }

--- a/modules/aks/github-connector/buildingblock/repo_content/Dockerfile
+++ b/modules/aks/github-connector/buildingblock/repo_content/Dockerfile
@@ -1,3 +1,0 @@
-FROM alpine:latest
-
-CMD ["sleep",  "3600"]

--- a/modules/aks/github-connector/buildingblock/repo_content/README.MD
+++ b/modules/aks/github-connector/buildingblock/repo_content/README.MD
@@ -1,9 +1,0 @@
-# ${github_repo}
-
-This GitHub repository was created via a meshStack building block and is automatically connected to both your development and production AKS namespaces through GitHub Actions. The GitHub Actions pipeline deploys the docker container (Dockerfile in your repository) from the repository to the respective AKS namespaces.
-
-## Deploy Your Application
-1. **Push your application code** including the required Dockerfile to this GitHub repository main branch
-2. **Your app will be deployed automatically** to the development AKS namespace via GitHub Actions when a commit is pushed to the main branch
-3. **To deploy to production**, create a pull request to merge the main branch into the release branch and merge the pull request. The GitHub Actions workflow will automatically deploy the application to the production AKS namespace.
-4. **Monitor deployments** in the [GitHub Actions tab](/actions) of your repository

--- a/modules/aks/github-connector/buildingblock/variables.tf
+++ b/modules/aks/github-connector/buildingblock/variables.tf
@@ -12,3 +12,9 @@ variable "branch" {
   type        = string
   default     = "main"
 }
+
+variable "init_shared_files" {
+  description = "Whether to initialize shared files (README.md and Dockerfile) in the repository"
+  type        = bool
+  default     = true
+}

--- a/modules/aks/github-connector/buildingblock/variables.tf
+++ b/modules/aks/github-connector/buildingblock/variables.tf
@@ -12,9 +12,3 @@ variable "branch" {
   type        = string
   default     = "main"
 }
-
-variable "init_shared_files" {
-  description = "Whether to initialize shared files (README.md and Dockerfile) in the repository"
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
In order to prevent race conditions when adding the same file from 2 building blocks that are executed in parallel, we decided to move the Dockerfile and Readme creation into a repository template which must be applied when already creating the repository. The GitHub Connector now has the existence of the Dockerfile as a precondition. This also makes it better reusable, as you could add it upon an existing repository that already has a Dockerfile. 