### PR TITLE
Improve template details source-link guidance

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,17 @@ const { execSync } = require("child_process");
 
 const repoRoot = path.resolve(__dirname, "modules");
 const assetsDir = path.resolve(__dirname, "website/public/assets/logos");
+const hubRef = getHubRef();
+
+function getHubRef() {
+  try {
+    return execSync("git rev-parse HEAD")
+      .toString()
+      .trim();
+  } catch {
+    return "main";
+  }
+}
 
 function getGitHubRemoteUrl() {
   try {
@@ -26,7 +37,7 @@ function getBuildingBlockFolderUrl(filePath) {
   const relativePath = filePath
     .replace(path.resolve(__dirname, "modules"), "")
     .replace(/\/README\.md$/, "");
-  return `${remoteUrl}/tree/main/modules${relativePath}`;
+  return `${remoteUrl}/tree/${hubRef}/modules${relativePath}`;
 }
 
 function findReadmes(dir){
@@ -52,6 +63,7 @@ function findPlatforms(): Platform[] {
       const platformReadme = getPlatformReadmeOrThrow(platformDir);
       const { name, description, category, benefits, content } = extractReadmeFrontMatter(platformReadme);
       const terraformSnippet = getTerraformSnippet(platformDir);
+      const integrationSourceUrl = getPlatformIntegrationSourceUrl(platformDir);
 
       return {
         platformType: dir.name,
@@ -61,9 +73,24 @@ function findPlatforms(): Platform[] {
         benefits,
         logo: platformLogo,
         readme: content,
+        integrationSourceUrl,
         terraformSnippet
       };
     });
+}
+
+function getPlatformIntegrationSourceUrl(platformDir: string): string | null {
+  const remoteUrl = getGitHubRemoteUrl();
+  if (!remoteUrl) return null;
+
+  const tfFile = path.join(platformDir, "meshstack_integration.tf");
+  if (!fs.existsSync(tfFile)) return null;
+
+  const relativePath = platformDir
+    .replace(path.resolve(__dirname, "modules"), "")
+    .replace(/\\/g, "/");
+
+  return `${remoteUrl}/blob/${hubRef}/modules${relativePath}/meshstack_integration.tf`;
 }
 
 // Finds the logo, copies it to website assets and returns the path.
@@ -242,5 +269,6 @@ export interface Platform {
   readme: string;
   category?: string;
   benefits?: string[];
+  integrationSourceUrl?: string | null;
   terraformSnippet?: string;
 }

--- a/website/.eslintrc.json
+++ b/website/.eslintrc.json
@@ -378,6 +378,7 @@
           {
             "allowList": [
               "close",
+              "copyModuleCode",
               "copyTerraform",
               "getCategoryLabel",
               "navigateToRoutePath",

--- a/website/.eslintrc.json
+++ b/website/.eslintrc.json
@@ -373,7 +373,22 @@
         "plugin:@angular-eslint/template/accessibility"
       ],
       "rules": {
-        "@angular-eslint/template/no-call-expression": "warn",
+        "@angular-eslint/template/no-call-expression": [
+          "warn",
+          {
+            "allowList": [
+              "close",
+              "copyTerraform",
+              "getCategoryLabel",
+              "navigateToRoutePath",
+              "onBackgroundColorExtracted",
+              "onSearch",
+              "open",
+              "openMeshStackUrl",
+              "scrollToTerraform"
+            ]
+          }
+        ],
         "@angular-eslint/template/no-negated-async": "warn",
 
         // ESLint Accessibility Keyboard Navigation

--- a/website/src/app/features/platform-integration/platform-integration.component.html
+++ b/website/src/app/features/platform-integration/platform-integration.component.html
@@ -83,13 +83,14 @@
             <!-- Right Column: Code -->
             <div class="relative w-full overflow-hidden">
               <button
+                type="button"
                 (click)="copyTerraform(platform.terraformSnippet!!)"
                 class="absolute top-3 right-3 btn btn-xs btn-primary z-10 font-bold flex items-center gap-2"
                 [class.btn-success]="copiedTerraform">
                 <i class="fa-solid" [class.fa-check]="copiedTerraform" [class.fa-copy]="!copiedTerraform"></i>
                 <span>{{ copiedTerraform ? 'Copied!' : 'Copy' }}</span>
               </button>
-              <pre class="bg-slate-900 text-slate-100 p-2 md:p-3 rounded-xl border border-slate-200 overflow-x-auto text-xs md:text-sm mt-0 w-full whitespace-pre"><code class="language-hcl" highlight>{{ platform?.terraformSnippet }}</code></pre>
+              <pre class="bg-slate-900 text-slate-100 p-2 md:p-3 rounded-xl border border-slate-200 overflow-x-auto text-xs md:text-sm mt-0 w-full whitespace-pre"><code class="language-hcl" mstHighlight>{{ platform?.terraformSnippet }}</code></pre>
             </div>
           </div>
         </div>
@@ -99,7 +100,7 @@
 </div>
 
 <!-- Not Found State -->
-<div class="bg-slate-50 min-h-screen flex items-center justify-center" *ngIf="!(platform$ | async)">
+<div class="bg-slate-50 min-h-screen flex items-center justify-center" *ngIf="(platform$ | async) === null || (platform$ | async) === undefined">
   <div class="text-center">
     <i class="fa-solid fa-circle-exclamation text-6xl text-slate-400 mb-4"></i>
     <h2 class="text-2xl font-bold text-slate-900 mb-2">Integration Not Found</h2>

--- a/website/src/app/features/platform-integration/platform-integration.component.html
+++ b/website/src/app/features/platform-integration/platform-integration.component.html
@@ -1,4 +1,4 @@
-<div class="bg-slate-50 min-h-screen" *ngIf="platform$ | async as platform">
+<div class="bg-slate-50 min-h-screen" *ngIf="platform$ | async as platform; else platformNotFound">
   <!-- Breadcrumb -->
   <div class="border-b border-slate-200 w-full">
     <div class="container mx-auto px-4 lg:px-8">
@@ -26,6 +26,15 @@
               <span>{{ benefit }}</span>
             </span>
           </div>
+          <a
+            *ngIf="platform.integrationSourceUrl"
+            [href]="platform.integrationSourceUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex w-fit items-center gap-2 rounded-md border border-slate-300 bg-white/80 px-3 py-1.5 text-sm text-slate-700 hover:border-slate-400 hover:text-slate-900 transition-colors">
+            <img src="assets/logos/github.png" alt="" class="w-4 h-4" />
+            <span>View source on GitHub</span>
+          </a>
         </div>
       </div>
     </div>
@@ -51,6 +60,19 @@
                   <div class="flex-1">
                     <div class="text-slate-700 font-medium mb-1 text-base">Add the OpenTofu snippet</div>
                     <div class="text-slate-600 text-sm">Copy the provided OpenTofu code from the right and add it to your infrastructure codebase.</div>
+                    <div class="mt-2">
+                      <button
+                        type="button"
+                        class="inline-flex items-center gap-1 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-800"
+                        [disabled]="!platform.moduleCodeSnippet"
+                        [class.border-slate-300]="copiedModuleCode"
+                        [class.bg-slate-100]="copiedModuleCode"
+                        [class.text-slate-700]="copiedModuleCode"
+                        (click)="copyModuleCode(platform.moduleCodeSnippet)">
+                        <i class="fa-solid" [class.fa-check]="copiedModuleCode" [class.fa-copy]="!copiedModuleCode"></i>
+                        <span>{{ copiedModuleCode ? 'Copied!' : 'Copy module code' }}</span>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div class="flex gap-3 items-start">
@@ -100,13 +122,15 @@
 </div>
 
 <!-- Not Found State -->
-<div class="bg-slate-50 min-h-screen flex items-center justify-center" *ngIf="(platform$ | async) === null || (platform$ | async) === undefined">
-  <div class="text-center">
-    <i class="fa-solid fa-circle-exclamation text-6xl text-slate-400 mb-4"></i>
-    <h2 class="text-2xl font-bold text-slate-900 mb-2">Integration Not Found</h2>
-    <p class="text-slate-600 mb-4">This platform does not have an integration available yet.</p>
-    <a routerLink="/" class="btn btn-primary">
-      <i class="fa-solid fa-home mr-2"></i>Back to Home
-    </a>
+<ng-template #platformNotFound>
+  <div class="bg-slate-50 min-h-screen flex items-center justify-center">
+    <div class="text-center">
+      <i class="fa-solid fa-circle-exclamation text-6xl text-slate-400 mb-4"></i>
+      <h2 class="text-2xl font-bold text-slate-900 mb-2">Integration Not Found</h2>
+      <p class="text-slate-600 mb-4">This platform does not have an integration available yet.</p>
+      <a routerLink="/" class="btn btn-primary">
+        <i class="fa-solid fa-home mr-2"></i>Back to Home
+      </a>
+    </div>
   </div>
-</div>
+</ng-template>

--- a/website/src/app/features/platform-integration/platform-integration.component.ts
+++ b/website/src/app/features/platform-integration/platform-integration.component.ts
@@ -10,8 +10,13 @@ import { CardComponent } from 'app/shared/card';
 import { HighlightDirective } from 'app/shared/directives';
 import { Platform, PlatformService } from 'app/shared/platform';
 import { extractLogoColor } from 'app/shared/util/logo-color.util';
+import { buildHubModuleCodeSnippet } from 'app/shared/util/module-source.util';
 
 const DEFAULT_HEADER_BG_COLOR = 'rgba(203,213,225,0.3)';
+
+interface PlatformIntegrationVm extends Platform {
+  moduleCodeSnippet: string | null;
+}
 
 @Component({
   selector: 'mst-platform-integration',
@@ -21,11 +26,13 @@ const DEFAULT_HEADER_BG_COLOR = 'rgba(203,213,225,0.3)';
   standalone: true
 })
 export class PlatformIntegrationComponent implements OnInit {
-  public platform$!: Observable<Platform>;
+  public platform$!: Observable<PlatformIntegrationVm>;
 
   public breadcrumbs$!: Observable<BreadcrumbItem[]>;
 
   public copiedTerraform = false;
+
+  public copiedModuleCode = false;
 
   public headerBgColor$!: Observable<string>;
 
@@ -53,7 +60,10 @@ export class PlatformIntegrationComponent implements OnInit {
                 throw new Error('Platform not found');
               }
 
-              return platform;
+              return {
+                ...platform,
+                moduleCodeSnippet: buildHubModuleCodeSnippet(platform.integrationSourceUrl)
+              };
             })
           );
       })
@@ -85,4 +95,19 @@ export class PlatformIntegrationComponent implements OnInit {
         plausible?.('Copy Platform Terraform');
       });
   }
+
+  public copyModuleCode(moduleCodeSnippet: string | null): void {
+    if (!moduleCodeSnippet) {
+      return;
+    }
+
+    navigator.clipboard.writeText(moduleCodeSnippet)
+      .then(() => {
+        this.copiedModuleCode = true;
+        setTimeout(() => {
+          this.copiedModuleCode = false;
+        }, 2000);
+      });
+  }
+
 }

--- a/website/src/app/features/platform-integration/platform-integration.component.ts
+++ b/website/src/app/features/platform-integration/platform-integration.component.ts
@@ -1,15 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { Observable, switchMap, of, map } from 'rxjs';
+import { Observable, map, of, switchMap } from 'rxjs';
 
 import { BreadcrumbComponent } from 'app/shared/breadcrumb';
 import { BreadCrumbService } from 'app/shared/breadcrumb/bread-crumb.service';
 import { BreadcrumbItem } from 'app/shared/breadcrumb/breadcrumb';
 import { CardComponent } from 'app/shared/card';
-import { PlatformService, Platform } from 'app/shared/platform';
-import { extractLogoColor } from 'app/shared/util/logo-color.util';
 import { HighlightDirective } from 'app/shared/directives';
+import { Platform, PlatformService } from 'app/shared/platform';
+import { extractLogoColor } from 'app/shared/util/logo-color.util';
 
 const DEFAULT_HEADER_BG_COLOR = 'rgba(203,213,225,0.3)';
 
@@ -22,8 +22,11 @@ const DEFAULT_HEADER_BG_COLOR = 'rgba(203,213,225,0.3)';
 })
 export class PlatformIntegrationComponent implements OnInit {
   public platform$!: Observable<Platform>;
+
   public breadcrumbs$!: Observable<BreadcrumbItem[]>;
+
   public copiedTerraform = false;
+
   public headerBgColor$!: Observable<string>;
 
   constructor(
@@ -36,16 +39,20 @@ export class PlatformIntegrationComponent implements OnInit {
     this.platform$ = this.route.paramMap.pipe(
       switchMap(params => {
         const type = params.get('type');
+
         if (!type) {
           throw new Error('Platform type not given in URL');
         }
+
         return this.platformService.getAllPlatforms()
           .pipe(
             map(platforms => {
               const platform = platforms.find(p => p.platformType === type);
+
               if (!platform) {
                 throw new Error('Platform not found');
               }
+
               return platform;
             })
           );
@@ -60,10 +67,9 @@ export class PlatformIntegrationComponent implements OnInit {
     this.headerBgColor$ = this.platform$.pipe(
       switchMap(platform =>
         platform && platform.logo
-          ? extractLogoColor(platform.logo).pipe(
-              map(color => {
-                return color || DEFAULT_HEADER_BG_COLOR;
-              })
+          ? extractLogoColor(platform.logo)
+            .pipe(
+              map(color => color || DEFAULT_HEADER_BG_COLOR)
             )
           : of(DEFAULT_HEADER_BG_COLOR)
       )
@@ -71,10 +77,12 @@ export class PlatformIntegrationComponent implements OnInit {
   }
 
   public copyTerraform(content: string): void {
-    navigator.clipboard.writeText(content).then(() => {
-      this.copiedTerraform = true;
-      setTimeout(() => this.copiedTerraform = false, 2000);
-      (window as any).plausible('Copy Platform Terraform');
-    });
+    navigator.clipboard.writeText(content)
+      .then(() => {
+        this.copiedTerraform = true;
+        setTimeout(() => this.copiedTerraform = false, 2000);
+        const plausible = (window as Window & { plausible?: (eventName: string) => void }).plausible;
+        plausible?.('Copy Platform Terraform');
+      });
   }
 }

--- a/website/src/app/features/platform-view/platform-view.component.ts
+++ b/website/src/app/features/platform-view/platform-view.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Observable, Subscription, map, switchMap, of } from 'rxjs';
+import { Observable, Subscription, map, of, switchMap } from 'rxjs';
 
+import { Template } from 'app/core';
 import { BreadcrumbComponent } from 'app/shared/breadcrumb';
 import { BreadCrumbService } from 'app/shared/breadcrumb/bread-crumb.service';
 import { BreadcrumbItem } from 'app/shared/breadcrumb/breadcrumb';
@@ -33,13 +34,13 @@ export class PlatformViewComponent implements OnInit, OnDestroy {
 
   public templates$!: Observable<DefinitionCard[]>;
 
-  public hasIntegration: boolean = false;
+  public hasIntegration = false;
 
-  public currentPlatformType: string = '';
-
-  private paramSubscription!: Subscription;
+  public currentPlatformType = '';
 
   public logoBackgroundColor$!: Observable<string>;
+
+  private paramSubscription!: Subscription;
 
   constructor(
     private router: Router,
@@ -77,6 +78,7 @@ export class PlatformViewComponent implements OnInit, OnDestroy {
               }
 
               this.hasIntegration = !!platform.terraformSnippet;
+
               return {
                 logo: platform.logo,
                 title: platform.name,
@@ -84,13 +86,14 @@ export class PlatformViewComponent implements OnInit, OnDestroy {
                 benefits: platform.benefits
               };
             })
-        );
+          );
         // Compose logoBackgroundColor$ reactively from platform$
         const DEFAULT_LOGO_BG_COLOR = 'rgba(203,213,225,0.3)';
         this.logoBackgroundColor$ = this.platform$.pipe(
           switchMap(platform =>
             platform.logo
-              ? extractLogoColor(platform.logo).pipe(
+              ? extractLogoColor(platform.logo)
+                .pipe(
                   map(color => color || DEFAULT_LOGO_BG_COLOR)
                 )
               : of(DEFAULT_LOGO_BG_COLOR)
@@ -105,7 +108,7 @@ export class PlatformViewComponent implements OnInit, OnDestroy {
   }
 
   private getTemplatesWithLogos(
-    templateObs$: Observable<any>,
+    templateObs$: Observable<Template[]>,
     platforms: Platform[],
     type: string
   ): Observable<DefinitionCard[]> {
@@ -119,7 +122,7 @@ export class PlatformViewComponent implements OnInit, OnDestroy {
             routePath: `/platforms/${type}/definitions/${item.id}`,
             supportedPlatforms: item.supportedPlatforms.map(platform => ({
               platformType: platform,
-              imageUrl: platforms.find(p => p.platformType === item.platformType)?.logo ?? null
+              imageUrl: platforms.find(p => p.platformType === platform)?.logo ?? 'assets/meshstack-logo.png'
             }))
           }))
         )

--- a/website/src/app/features/template-details/import-dialog/import-dialog.component.ts
+++ b/website/src/app/features/template-details/import-dialog/import-dialog.component.ts
@@ -1,7 +1,7 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 
 import { ReferrerService } from 'app/referrer.service';
 

--- a/website/src/app/features/template-details/template-details.component.html
+++ b/website/src/app/features/template-details/template-details.component.html
@@ -136,13 +136,14 @@
             <!-- Right Column: Code -->
             <div class="relative w-full overflow-hidden">
               <button
+                type="button"
                 (click)="copyTerraform(template.terraformSnippet)"
                 class="absolute top-3 right-3 btn btn-xs btn-primary z-10 font-bold flex items-center gap-2"
                 [class.btn-success]="copiedTerraform">
                 <i class="fa-solid" [class.fa-check]="copiedTerraform" [class.fa-copy]="!copiedTerraform"></i>
                 <span>{{ copiedTerraform ? 'Copied!' : 'Copy' }}</span>
               </button>
-              <pre class="bg-slate-900 text-slate-100 p-2 md:p-3 rounded-xl border border-slate-200 overflow-x-auto text-xs md:text-sm mt-0 w-full whitespace-pre"><code class="language-hcl" highlight>{{ template.terraformSnippet }}</code></pre>
+              <pre class="bg-slate-900 text-slate-100 p-2 md:p-3 rounded-xl border border-slate-200 overflow-x-auto text-xs md:text-sm mt-0 w-full whitespace-pre"><code class="language-hcl" mstHighlight>{{ template.terraformSnippet }}</code></pre>
             </div>
           </div>
         </div>
@@ -256,7 +257,7 @@
 </div>
 
 <!-- Not Found State -->
-<div class="bg-slate-50 min-h-screen flex items-center justify-center" *ngIf="!(template$ | async)">
+<div class="bg-slate-50 min-h-screen flex items-center justify-center" *ngIf="(template$ | async) === null || (template$ | async) === undefined">
   <div class="text-center">
     <i class="fa-solid fa-circle-exclamation text-6xl text-slate-400 mb-4"></i>
     <h2 class="text-2xl font-bold text-slate-900 mb-2">Building Block Not Found</h2>

--- a/website/src/app/features/template-details/template-details.component.html
+++ b/website/src/app/features/template-details/template-details.component.html
@@ -1,4 +1,4 @@
-<div class="bg-slate-50 min-h-screen" *ngIf="template$ | async as template">
+<div class="bg-slate-50 min-h-screen" *ngIf="template$ | async as template; else templateNotFound">
   <!-- Breadcrumb -->
   <div class="border-b border-slate-200 w-full">
     <div class="container mx-auto px-4 lg:px-8">
@@ -33,8 +33,9 @@
                 *ngIf="template.terraformSnippet"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-block text-sm text-slate-600 hover:text-slate-900 mt-3 transition-colors">
-                View source on GitHub
+                class="inline-flex items-center gap-2 mt-3 rounded-md border border-slate-300 bg-white/80 px-3 py-1.5 text-sm text-slate-700 hover:border-slate-400 hover:text-slate-900 transition-colors">
+                <img src="assets/logos/github.png" alt="" class="w-4 h-4" />
+                <span>View source on GitHub</span>
               </a>
             </div>
             <!-- Action Buttons -->
@@ -103,7 +104,22 @@
                   <div class="flex-shrink-0 w-6 h-6 rounded-full bg-primary-100 text-primary-600 flex items-center justify-center text-sm font-semibold">1</div>
                   <div class="flex-1">
                     <div class="text-slate-700 font-medium mb-1 text-base">Add the OpenTofu snippet</div>
-                    <div class="text-slate-600 text-sm">Copy the provided OpenTofu code from the right and add it to your infrastructure codebase.</div>
+                    <div class="text-slate-600 text-sm">
+                      Copy the provided OpenTofu code from the right and add it to your infrastructure codebase.
+                    </div>
+                    <div class="mt-2">
+                      <button
+                        type="button"
+                        class="inline-flex items-center gap-1 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-800"
+                        [disabled]="!template.moduleCodeSnippet"
+                        [class.border-slate-300]="copiedModuleCode"
+                        [class.bg-slate-100]="copiedModuleCode"
+                        [class.text-slate-700]="copiedModuleCode"
+                        (click)="copyModuleCode(template.moduleCodeSnippet)">
+                        <i class="fa-solid" [class.fa-check]="copiedModuleCode" [class.fa-copy]="!copiedModuleCode"></i>
+                        <span>{{ copiedModuleCode ? 'Copied!' : 'Copy module code' }}</span>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div class="flex gap-3 items-start">
@@ -257,13 +273,15 @@
 </div>
 
 <!-- Not Found State -->
-<div class="bg-slate-50 min-h-screen flex items-center justify-center" *ngIf="(template$ | async) === null || (template$ | async) === undefined">
-  <div class="text-center">
-    <i class="fa-solid fa-circle-exclamation text-6xl text-slate-400 mb-4"></i>
-    <h2 class="text-2xl font-bold text-slate-900 mb-2">Building Block Not Found</h2>
-    <p class="text-slate-600 mb-4">This building block does not exist or has been removed.</p>
-    <a routerLink="/" class="btn btn-primary">
-      <i class="fa-solid fa-home mr-2"></i>Back to Home
-    </a>
+<ng-template #templateNotFound>
+  <div class="bg-slate-50 min-h-screen flex items-center justify-center">
+    <div class="text-center">
+      <i class="fa-solid fa-circle-exclamation text-6xl text-slate-400 mb-4"></i>
+      <h2 class="text-2xl font-bold text-slate-900 mb-2">Building Block Not Found</h2>
+      <p class="text-slate-600 mb-4">This building block does not exist or has been removed.</p>
+      <a routerLink="/" class="btn btn-primary">
+        <i class="fa-solid fa-home mr-2"></i>Back to Home
+      </a>
+    </div>
   </div>
-</div>
+</ng-template>

--- a/website/src/app/features/template-details/template-details.component.ts
+++ b/website/src/app/features/template-details/template-details.component.ts
@@ -1,18 +1,18 @@
+import { Dialog } from '@angular/cdk/dialog';
 import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { Dialog } from '@angular/cdk/dialog';
-import { Observable, Subscription, map, switchMap, of } from 'rxjs';
+import { Observable, Subscription, map, of, switchMap } from 'rxjs';
 
 import { BreadCrumbService } from 'app/shared/breadcrumb/bread-crumb.service';
 import { BreadcrumbItem } from 'app/shared/breadcrumb/breadcrumb';
 import { BreadcrumbComponent } from 'app/shared/breadcrumb/breadcrumb.component';
 import { CardComponent } from 'app/shared/card';
+import { HighlightDirective } from 'app/shared/directives';
 import { TemplateService } from 'app/shared/template';
 import { extractLogoColor } from 'app/shared/util/logo-color.util';
 
 import { ImportDialogComponent } from './import-dialog/import-dialog.component';
-import { HighlightDirective } from 'app/shared/directives';
 
 const DEFAULT_HEADER_BG_COLOR = 'rgba(203,213,225,0.3)';
 
@@ -69,7 +69,8 @@ export class TemplateDetailsComponent implements OnInit, OnDestroy {
     this.headerBgColor$ = this.template$.pipe(
       switchMap(template =>
         template && template.imageUrl
-          ? extractLogoColor(template.imageUrl).pipe(
+          ? extractLogoColor(template.imageUrl)
+            .pipe(
               map(color => color || DEFAULT_HEADER_BG_COLOR)
             )
           : of(DEFAULT_HEADER_BG_COLOR)
@@ -93,12 +94,14 @@ export class TemplateDetailsComponent implements OnInit, OnDestroy {
         setTimeout(() => {
           this.copiedTerraform = false;
         }, 2000);
-        (window as any).plausible('Copy BBD Terraform');
+        const plausible = (window as Window & { plausible?: (eventName: string) => void }).plausible;
+        plausible?.('Copy BBD Terraform');
       });
   }
 
   public scrollToTerraform(): void {
     const terraformCard = document.querySelector('mst-card');
+
     if (terraformCard) {
       terraformCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }

--- a/website/src/app/features/template-details/template-details.component.ts
+++ b/website/src/app/features/template-details/template-details.component.ts
@@ -11,6 +11,7 @@ import { CardComponent } from 'app/shared/card';
 import { HighlightDirective } from 'app/shared/directives';
 import { TemplateService } from 'app/shared/template';
 import { extractLogoColor } from 'app/shared/util/logo-color.util';
+import { buildHubModuleCodeSnippet } from 'app/shared/util/module-source.util';
 
 import { ImportDialogComponent } from './import-dialog/import-dialog.component';
 
@@ -23,6 +24,7 @@ interface TemplateDetailsVm {
   description: string;
   howToUse: string;
   source: string;
+  moduleCodeSnippet: string | null;
   backplaneUrl: string | null;
   terraformSnippet?: string;
 }
@@ -44,6 +46,8 @@ export class TemplateDetailsComponent implements OnInit, OnDestroy {
   public copyLabel = 'Copy';
 
   public copiedTerraform = false;
+
+  public copiedModuleCode = false;
 
   public headerBgColor$!: Observable<string>;
 
@@ -99,6 +103,20 @@ export class TemplateDetailsComponent implements OnInit, OnDestroy {
       });
   }
 
+  public copyModuleCode(moduleCodeSnippet: string | null): void {
+    if (!moduleCodeSnippet) {
+      return;
+    }
+
+    navigator.clipboard.writeText(moduleCodeSnippet)
+      .then(() => {
+        this.copiedModuleCode = true;
+        setTimeout(() => {
+          this.copiedModuleCode = false;
+        }, 2000);
+      });
+  }
+
   public scrollToTerraform(): void {
     const terraformCard = document.querySelector('mst-card');
 
@@ -144,6 +162,7 @@ export class TemplateDetailsComponent implements OnInit, OnDestroy {
             ...template,
             imageUrl: template.logo,
             source: template.buildingBlockUrl,
+            moduleCodeSnippet: buildHubModuleCodeSnippet(template.buildingBlockUrl),
             howToUse: template.howToUse,
             terraformSnippet: template.terraformSnippet
           }))

--- a/website/src/app/features/template-gallery/platform-cards/platform-cards.component.ts
+++ b/website/src/app/features/template-gallery/platform-cards/platform-cards.component.ts
@@ -31,10 +31,12 @@ export class PlatformCardsComponent {
    * Returns the cards sorted by customOrder, with others following in original order.
    */
   public get sortedCards(): PlatformCard[] {
-    if (!this.cards) return [];
+    if (!this.cards) {return [];}
     const order = this.customOrder;
+
     return [
-      ...this.cards.filter(card => order.includes(card.title)).sort((a, b) => order.indexOf(a.title) - order.indexOf(b.title)),
+      ...this.cards.filter(card => order.includes(card.title))
+        .sort((a, b) => order.indexOf(a.title) - order.indexOf(b.title)),
       ...this.cards.filter(card => !order.includes(card.title))
     ];
   }
@@ -46,21 +48,21 @@ export class PlatformCardsComponent {
   }
 
   public getCategoryLabel(category?: 'hyperscaler' | 'european' | 'china' | 'devops' | 'private-cloud'): { emoji: string; text: string } | null {
-    if (!category) return null;
+    if (!category) {return null;}
 
     switch (category) {
-      case 'hyperscaler':
-        return { emoji: '🌐', text: 'Hyperscaler' };
-      case 'european':
-        return { emoji: '🇪🇺', text: 'European' };
-      case 'china':
-        return { emoji: '🇨🇳', text: 'China' };
-      case 'devops':
-        return { emoji: '🔧', text: 'DevOps' };
-      case 'private-cloud':
-        return { emoji: '🔒', text: 'Private Cloud' };
-      default:
-        return null;
+    case 'hyperscaler':
+      return { emoji: '🌐', text: 'Hyperscaler' };
+    case 'european':
+      return { emoji: '🇪🇺', text: 'European' };
+    case 'china':
+      return { emoji: '🇨🇳', text: 'China' };
+    case 'devops':
+      return { emoji: '🔧', text: 'DevOps' };
+    case 'private-cloud':
+      return { emoji: '🔒', text: 'Private Cloud' };
+    default:
+      return null;
     }
   }
 }

--- a/website/src/app/features/template-gallery/template-gallery.component.ts
+++ b/website/src/app/features/template-gallery/template-gallery.component.ts
@@ -3,6 +3,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable, Subscription, combineLatest, forkJoin, map } from 'rxjs';
 
+import { Template } from 'app/core';
 import { BreadcrumbComponent } from 'app/shared/breadcrumb';
 import { BreadcrumbItem } from 'app/shared/breadcrumb/breadcrumb';
 import { DefinitionCard } from 'app/shared/definition-card/definition-card';
@@ -78,7 +79,7 @@ export class TemplateGalleryComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getTemplatesWithLogos(templateObs$: Observable<any>): Observable<DefinitionCard[]> {
+  private getTemplatesWithLogos(templateObs$: Observable<Template[]>): Observable<DefinitionCard[]> {
     return forkJoin({ templates: templateObs$, platforms: this.platforms$ })
       .pipe(
         map(({ templates, platforms }) =>
@@ -88,10 +89,11 @@ export class TemplateGalleryComponent implements OnInit, OnDestroy {
   }
 
   private getFilteredPlatformCards(searchTerm: string | undefined): Observable<PlatformCard[]> {
-    return combineLatest([this.platforms$, this.templateService.filterTemplatesByPlatformType('all')]).pipe(
-      map(([platforms, templates]) => this.mapLogosToPlatformCards(platforms, templates)),
-      map(cards => this.filterCardsBySearchTerm(cards, searchTerm))
-    );
+    return combineLatest([this.platforms$, this.templateService.filterTemplatesByPlatformType('all')])
+      .pipe(
+        map(([platforms, templates]) => this.mapLogosToPlatformCards(platforms, templates)),
+        map(cards => this.filterCardsBySearchTerm(cards, searchTerm))
+      );
   }
 
   private getBreadcrumbs(): Observable<BreadcrumbItem[]> {
@@ -101,15 +103,15 @@ export class TemplateGalleryComponent implements OnInit, OnDestroy {
       );
   }
 
-  private mapToDefinitionCard(template: any, platforms: Platform[]): DefinitionCard {
+  private mapToDefinitionCard(template: Template, platforms: Platform[]): DefinitionCard {
     return {
       cardLogo: template.logo,
       title: template.name,
       description: template.description,
       routePath: `/definitions/${template.id}`,
-      supportedPlatforms: template.supportedPlatforms.map(platform => ({
+      supportedPlatforms: (template.supportedPlatforms ?? []).map(platform => ({
         platformType: platform,
-        imageUrl: platforms.find(p => p.platformType === platform)?.logo ?? null
+        imageUrl: platforms.find(p => p.platformType === platform)?.logo ?? 'assets/meshstack-logo.png'
       }))
     };
   }
@@ -121,9 +123,10 @@ export class TemplateGalleryComponent implements OnInit, OnDestroy {
     ];
   }
 
-  private mapLogosToPlatformCards(data: Platform[], templates: any[]): PlatformCard[] {
+  private mapLogosToPlatformCards(data: Platform[], templates: Template[]): PlatformCard[] {
     return data.map(platform => {
       const buildingBlockCount = templates.filter(t => t.platformType === platform.platformType).length;
+
       return this.createPlatformCard(
         platform.name,
         platform.logo,

--- a/website/src/app/shared/breadcrumb/bread-crumb.service.ts
+++ b/website/src/app/shared/breadcrumb/bread-crumb.service.ts
@@ -49,7 +49,7 @@ export class BreadCrumbService {
     templateName: string | null,
     platformName: string | null,
     type: string | null,
-    isIntegration: boolean = false
+    isIntegration = false
   ): BreadcrumbItem[] {
     const breadcrumbs: BreadcrumbItem[] = [{ label: 'Home', routePath: '/' }];
 

--- a/website/src/app/shared/card/card.component.ts
+++ b/website/src/app/shared/card/card.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
+import { Observable, map, of, startWith, switchMap } from 'rxjs';
+
 import { extractLogoColor } from '../util/logo-color.util';
-import { Observable, of, map, switchMap, startWith } from 'rxjs';
 
 const DEFAULT_CARD_BG_COLOR = 'rgba(203,213,225,0.3)';
 
@@ -23,33 +24,36 @@ export class CardComponent {
   @Input()
   public accentColor = '';
 
-  private _logoSourceImage: string | null = '';
-
-  @Input()
-  set logoSourceImage(value: string | null) {
-    this._logoSourceImage = value;
-    this._logoSourceImage$ = of(value);
-  }
-  get logoSourceImage(): string | null {
-    return this._logoSourceImage;
-  }
-
   @Output()
   public backgroundColorExtracted = new EventEmitter<string>();
 
+  public logoBackgroundColor$: Observable<string> = of(DEFAULT_CARD_BG_COLOR);
+
+  private _logoSourceImage: string | null = '';
+
   private _logoSourceImage$: Observable<string | null> = of(null);
 
-  public logoBackgroundColor$: Observable<string> = of(DEFAULT_CARD_BG_COLOR);
+  @Input()
+  public set logoSourceImage(value: string | null) {
+    this._logoSourceImage = value;
+    this._logoSourceImage$ = of(value);
+  }
+
+  public get logoSourceImage(): string | null {
+    return this._logoSourceImage;
+  }
 
   constructor(private router: Router) {
     // Set up the reactive logo background color observable
     this.logoBackgroundColor$ = this._logoSourceImage$.pipe(
       switchMap(logo =>
         logo
-          ? extractLogoColor(logo).pipe(
+          ? extractLogoColor(logo)
+            .pipe(
               map(color => color || DEFAULT_CARD_BG_COLOR),
               map(color => {
                 this.backgroundColorExtracted.emit(color);
+
                 return color;
               })
             )

--- a/website/src/app/shared/directives/highlight.directive.ts
+++ b/website/src/app/shared/directives/highlight.directive.ts
@@ -1,17 +1,15 @@
-import { Directive, ElementRef, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef } from '@angular/core';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-hcl';
 
 @Directive({
-  selector: 'code[highlight]',
+  selector: 'code[mstHighlight]',
   standalone: true
 })
 export class HighlightDirective implements AfterViewInit {
   constructor(private el: ElementRef) {}
 
-  ngAfterViewInit(): void {
+  public ngAfterViewInit(): void {
     Prism.highlightElement(this.el.nativeElement);
   }
 }
-
-

--- a/website/src/app/shared/platform/platform-data.ts
+++ b/website/src/app/shared/platform/platform-data.ts
@@ -6,5 +6,6 @@ export interface Platform {
   benefits?: string[];
   logo: string;
   readme: string;
+  integrationSourceUrl?: string | null;
   terraformSnippet?: string;
 }

--- a/website/src/app/shared/search-bar/search-bar.component.ts
+++ b/website/src/app/shared/search-bar/search-bar.component.ts
@@ -15,6 +15,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   public searchForm!: FormGroup;
 
   private routerSubscription!: Subscription;
+
   private searchSubscription!: Subscription;
 
   constructor(
@@ -46,7 +47,13 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 
   private setupLiveSearch(): void {
     // Live search with debounce - searches as user types
-    this.searchSubscription = this.searchForm.get('searchTerm')!.valueChanges
+    const searchTermControl = this.searchForm.get('searchTerm');
+
+    if (!searchTermControl) {
+      throw new Error('searchTerm form control missing');
+    }
+
+    this.searchSubscription = searchTermControl.valueChanges
       .pipe(
         debounceTime(300), // Wait 300ms after user stops typing
         distinctUntilChanged() // Only emit when value actually changes

--- a/website/src/app/shared/util/logo-color.util.ts
+++ b/website/src/app/shared/util/logo-color.util.ts
@@ -12,6 +12,7 @@ export function extractLogoColor(imageUrl: string, alpha = 0.1): Observable<stri
     if (!imageUrl || typeof window === 'undefined') {
       observer.next(null);
       observer.complete();
+
       return;
     }
     const img = new Image();

--- a/website/src/app/shared/util/module-source.util.ts
+++ b/website/src/app/shared/util/module-source.util.ts
@@ -1,0 +1,80 @@
+function sanitizeModuleName(modulePath: string): string | null {
+  const moduleName = modulePath.split('/')
+    .pop()
+    ?.replace(/[^a-zA-Z0-9_]/g, '_');
+
+  return moduleName ?? null;
+}
+
+export function extractHubModulePath(source: string): string | null {
+  const modulesMarker = '/modules/';
+  const modulesStart = source.indexOf(modulesMarker);
+
+  if (modulesStart === -1) {
+    return null;
+  }
+
+  const tail = source.slice(modulesStart + 1)
+    .split(/[?#]/)[0];
+  const segments = tail.split('/')
+    .filter(Boolean);
+
+  if (segments[0] !== 'modules' || segments.length < 2) {
+    return null;
+  }
+
+  if (segments.length === 2 || segments[2].endsWith('.tf')) {
+    return segments.slice(0, 2)
+      .join('/');
+  }
+
+  return segments.slice(0, 3)
+    .join('/');
+}
+
+export function extractHubGitRef(source: string): string | null {
+  const treeMarker = '/tree/';
+  const blobMarker = '/blob/';
+  const modulesMarker = '/modules/';
+  const treeIndex = source.indexOf(treeMarker);
+  const blobIndex = source.indexOf(blobMarker);
+  const markerIndex = treeIndex !== -1 ? treeIndex : blobIndex;
+  const markerLength = treeIndex !== -1 ? treeMarker.length : blobMarker.length;
+
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const refStart = markerIndex + markerLength;
+  const refEnd = source.indexOf(modulesMarker, refStart);
+
+  if (refEnd === -1 || refEnd <= refStart) {
+    return null;
+  }
+
+  return source.slice(refStart, refEnd);
+}
+
+export function buildHubModuleCodeSnippet(source: string | null | undefined): string | null {
+  if (!source) {
+    return null;
+  }
+
+  const modulePath = extractHubModulePath(source);
+  const ref = extractHubGitRef(source);
+
+  if (!modulePath || !ref) {
+    return null;
+  }
+
+  const moduleName = sanitizeModuleName(modulePath);
+
+  if (!moduleName) {
+    return null;
+  }
+
+  return `module "${moduleName}" {
+  source = "github.com/meshcloud/meshstack-hub//${modulePath}?ref=${ref}"
+  # Define input variables here
+}`;
+}

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -5,6 +5,6 @@ import { appConfig } from './app/app.config';
 
 
 bootstrapApplication(AppComponent, appConfig)
-  .catch(err =>
-    console.error(err)
-  );
+  .catch(err => {
+    throw err;
+  });


### PR DESCRIPTION
## Summary
This PR improves source guidance in the Hub UI and encourages pinned module usage.

## Visible changes
- Building block details show a clearer View source on GitHub action and a subtle Copy module code button.
- Platform integration pages (for example Azure) now also show View source on GitHub and Copy module code actions.
- Copy module snippets now use valid Terraform git module source syntax (`//`), robust ref parsing, and shared frontend helpers.
- Not-found states were switched to top-level `*ngIf ... else` rendering to avoid duplicate async subscriptions.
- Generated Hub links are pinned to the current commit SHA via `git rev-parse HEAD` in `index.ts` (fallback: `main`).
