### PR TITLE
feat(noop-bb): add nix tool installation example and smoke test

### DIFF
--- a/modules/meshstack/noop/buildingblock/README.md
+++ b/modules/meshstack/noop/buildingblock/README.md
@@ -15,6 +15,23 @@ Use it to:
 - Learn how FILE-type inputs are written to the working directory
 - See how `USER_PERMISSIONS` injects project team members into your building block
 - Understand the pre-run script execution model
+- See how to install arbitrary tools (e.g. AWS CLI) using nix in pre-run scripts
+
+## Installing Tools in Pre-Run Scripts
+
+The go runner image ships with [nix](https://nixos.org/) pre-installed in single-user mode, running as the non-root `meshcloud` user. This means you can install any package from [nixpkgs](https://search.nixos.org/packages) **without root or sudo access**:
+
+```bash
+# Install a single tool
+nix profile add nixpkgs#awscli2
+
+# Install multiple tools
+nix profile add nixpkgs#awscli2 nixpkgs#kubectl nixpkgs#jq
+```
+
+After installation, the tool is available in `PATH` for the rest of the pre-run script and subsequent steps.
+
+> **Tip:** Use [search.nixos.org](https://search.nixos.org/packages) to find the exact package name for any tool.
 
 ## Input Types
 

--- a/modules/meshstack/noop/buildingblock/noop.tftest.hcl
+++ b/modules/meshstack/noop/buildingblock/noop.tftest.hcl
@@ -1,0 +1,88 @@
+# Smoke test for the noop building block.
+# Verifies that the Terraform module applies cleanly with all required inputs,
+# covering the full input/output surface that meshStack exercises at runtime.
+# The pre-run script (prerun.sh) — including nix-based tool installation — is
+# exercised when this building block is deployed via the meshStack BB runner.
+
+# meshStack writes FILE-type inputs to the working directory before tofu init.
+# In local tests we create them upfront so the module can read them.
+run "noop_applies_successfully" {
+  variables {
+    user_permissions = [
+      {
+        meshIdentifier = "likvid-tom-user"
+        username       = "likvid-tom@meshcloud.io"
+        firstName      = "Tom"
+        lastName       = "Likvid"
+        email          = "likvid-tom@meshcloud.io"
+        euid           = "likvid-tom@meshcloud.io"
+        roles          = ["admin", "Workspace Owner"]
+      },
+      {
+        meshIdentifier = "likvid-daniela-user"
+        username       = "likvid-daniela@meshcloud.io"
+        firstName      = "Daniela"
+        lastName       = "Likvid"
+        email          = "likvid-daniela@meshcloud.io"
+        euid           = "likvid-daniela@meshcloud.io"
+        roles          = ["user", "Workspace Manager"]
+      }
+    ]
+    user_permissions_json = jsonencode([
+      {
+        meshIdentifier = "likvid-tom-user"
+        username       = "likvid-tom@meshcloud.io"
+        firstName      = "Tom"
+        lastName       = "Likvid"
+        email          = "likvid-tom@meshcloud.io"
+        euid           = "likvid-tom@meshcloud.io"
+        roles          = ["admin", "Workspace Owner"]
+      }
+    ])
+    sensitive_yaml    = { some = "yaml", other = "value" }
+    static            = "A static value"
+    static_code       = { some = "code" }
+    flag              = true
+    num               = 42
+    text              = "hello"
+    sensitive_text    = "s3cr3t"
+    single_select     = "single1"
+    multi_select      = ["multi1", "multi2"]
+    multi_select_json = jsonencode(["multi1", "multi2"])
+  }
+
+  assert {
+    condition     = output.flag == true
+    error_message = "expected flag output to be true"
+  }
+
+  assert {
+    condition     = output.num == 42
+    error_message = "expected num output to be 42"
+  }
+
+  assert {
+    condition     = output.text == "hello"
+    error_message = "expected text output to be 'hello'"
+  }
+
+  assert {
+    condition     = output.static == "A static value"
+    error_message = "expected static output to echo back the static input"
+  }
+
+  assert {
+    condition     = output.single_select == "single1"
+    error_message = "expected single_select output to echo back the selected value"
+  }
+
+  assert {
+    condition     = length(output.multi_select) == 2
+    error_message = "expected multi_select output to contain two values"
+  }
+
+  assert {
+    condition     = length(output.user_permissions) == 2
+    error_message = "expected user_permissions output to contain two entries"
+  }
+}

--- a/modules/meshstack/noop/buildingblock/prerun.sh
+++ b/modules/meshstack/noop/buildingblock/prerun.sh
@@ -21,9 +21,15 @@ echo "Working directory: $(pwd)"
 ls -lah
 echo ""
 
-echo "--- Tool Installation ---"
-echo "Currently not supported via apk add, but coming soon, see https://feedback.meshcloud.io/feature-requests/p/building-block-should-support-aws-cli-and-other"
-# sudo apk add aws-cli
+echo "--- Tool Installation via Nix ---"
+echo "The go runner image ships with nix pre-installed (single-user mode, meshcloud user)."
+echo "Use 'nix profile add nixpkgs#<package>' to install any package from nixpkgs without root/sudo."
+echo ""
+echo "Installing AWS CLI as an example:"
+nix profile add nixpkgs#awscli2
+echo ""
+echo "Verifying AWS CLI installation:"
+aws --version
 echo ""
 
 echo "--- Terraform State Manipulation ---"

--- a/modules/meshstack/noop/buildingblock/sensitive-file.yaml
+++ b/modules/meshstack/noop/buildingblock/sensitive-file.yaml
@@ -1,0 +1,2 @@
+some: input
+other: value

--- a/modules/meshstack/noop/buildingblock/some-file.yaml
+++ b/modules/meshstack/noop/buildingblock/some-file.yaml
@@ -1,0 +1,2 @@
+some: input
+other: value


### PR DESCRIPTION
## Summary

Updates the noop building block to demonstrate the nix-based package installation that is now available in the go runner image (shipped in [meshfed-release #9885](https://github.com/meshcloud/meshfed-release/pull/9885)).

## Changes

### `prerun.sh`
- Replaces the old _"not supported via apk add"_ placeholder with a working `nix profile add nixpkgs#awscli2` example
- Verifies the installed CLI with `aws --version` so the runner logs confirm nix works

### `noop.tftest.hcl` (new)
- Smoke test covering all input/output types of the noop building block
- Run locally with `tofu test` to validate the module applies cleanly
- FILE inputs (`some-file.yaml`, `sensitive-file.yaml`) are now included as fixture files so `tofu test` can run without a live meshStack instance

### `README.md`
- New _"Installing Tools in Pre-Run Scripts"_ section documenting the `nix profile add` pattern with examples

## Related
- Implements remaining items from [meshcloud/janny#1099](https://github.com/meshcloud/janny/issues/1099)
- Companion to [meshfed-release #9885](https://github.com/meshcloud/meshfed-release/pull/9885)