### PR TITLE
fix: migrate BB target_ref identifier to name for meshWorkspace

### DIFF
--- a/modules/azure/budget-alert/e2e/main.tf
+++ b/modules/azure/budget-alert/e2e/main.tf
@@ -54,8 +54,8 @@ resource "meshstack_building_block_v2" "this" {
 
     display_name = "smoke-test-budget-alert-${var.test_context.name_suffix}"
     target_ref = {
-      kind       = "meshWorkspace"
-      identifier = var.test_context.workspace
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
     }
 
     inputs = {

--- a/modules/azure/storage-account/e2e/main.tf
+++ b/modules/azure/storage-account/e2e/main.tf
@@ -56,8 +56,8 @@ resource "meshstack_building_block_v2" "this" {
 
     display_name = "smoke-test-storage-account-${var.test_context.name_suffix}"
     target_ref = {
-      kind       = "meshWorkspace"
-      identifier = var.test_context.workspace
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
     }
 
     inputs = {

--- a/modules/meshstack/manual/e2e/main.tf
+++ b/modules/meshstack/manual/e2e/main.tf
@@ -27,8 +27,8 @@ resource "meshstack_building_block_v2" "this" {
 
     display_name = "smoke-test-manual-hub-${var.test_context.name_suffix}"
     target_ref = {
-      kind       = "meshWorkspace"
-      identifier = var.test_context.workspace
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
     }
 
     inputs = {

--- a/modules/meshstack/noop/e2e/main.tf
+++ b/modules/meshstack/noop/e2e/main.tf
@@ -27,8 +27,8 @@ resource "meshstack_building_block_v2" "this" {
 
     display_name = "smoke-test-noop-hub-${var.test_context.name_suffix}"
     target_ref = {
-      kind       = "meshWorkspace"
-      identifier = var.test_context.workspace
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
     }
 
     inputs = {

--- a/modules/ske/ske-starterkit/e2e/main.tf
+++ b/modules/ske/ske-starterkit/e2e/main.tf
@@ -155,8 +155,8 @@ resource "meshstack_building_block_v2" "this" {
 
     display_name = "smoke-test-ske-starterkit-hub-${var.test_context.name_suffix}"
     target_ref = {
-      kind       = "meshWorkspace"
-      identifier = var.test_context.workspace
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
     }
 
     inputs = {

--- a/modules/stackit/git-repository/e2e/main.tf
+++ b/modules/stackit/git-repository/e2e/main.tf
@@ -38,8 +38,8 @@ resource "meshstack_building_block_v2" "this" {
 
     display_name = "smoke-test-stackit-git-repository-hub-${var.test_context.name_suffix}"
     target_ref = {
-      kind       = "meshWorkspace"
-      identifier = var.test_context.workspace
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
     }
 
     inputs = {


### PR DESCRIPTION
The meshStack API (v2026.22.0+) migrated building block target references
from SingleRef to SingleRefV2. For meshWorkspace targets, the field was
renamed from 'identifier' to 'name'.

Related: meshfed-release#9993, terraform-provider-meshstack#170
