### PR TITLE
fix(stackit/git-repository): resolve scorecard violations

### DIFF
--- a/modules/stackit/git-repository/backplane/README.md
+++ b/modules/stackit/git-repository/backplane/README.md
@@ -48,8 +48,7 @@ module "git_repo_backplane" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.4 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.4.0 |
 
 ## Modules
 

--- a/modules/stackit/git-repository/backplane/versions.tf
+++ b/modules/stackit/git-repository/backplane/versions.tf
@@ -1,10 +1,8 @@
 terraform {
-  required_version = ">= 1.4.0"
-
   required_providers {
     http = {
       source  = "hashicorp/http"
-      version = "~> 3.4"
+      version = "~> 3.4.0"
     }
   }
 }

--- a/modules/stackit/git-repository/buildingblock/README.md
+++ b/modules/stackit/git-repository/buildingblock/README.md
@@ -18,10 +18,9 @@ support action variables at all. See the sub-module README for details.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.0 |
 | <a name="requirement_forgejo"></a> [forgejo](#requirement\_forgejo) | ~> 1.3.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.8.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.8.0 |
 | <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | ~> 3.0.0 |
 
 ## Modules
@@ -35,7 +34,7 @@ support action variables at all. See the sub-module README for details.
 | Name | Type |
 |------|------|
 | [forgejo_repository.this](https://registry.terraform.io/providers/svalabs/forgejo/latest/docs/resources/repository) | resource |
-| [random_string.team_suffix](https://registry.terraform.io/providers/hashicorp/random/3.8.1/docs/resources/string) | resource |
+| [random_string.team_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [restapi_object.team](https://registry.terraform.io/providers/Mastercard/restapi/latest/docs/resources/object) | resource |
 | [terraform_data.team_member](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.team_repo](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/modules/stackit/git-repository/buildingblock/action-variables-and-secrets/versions.tf
+++ b/modules/stackit/git-repository/buildingblock/action-variables-and-secrets/versions.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 1.4.0"
-
   required_providers {
     restapi = {
       source                = "Mastercard/restapi"

--- a/modules/stackit/git-repository/buildingblock/versions.tf
+++ b/modules/stackit/git-repository/buildingblock/versions.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 1.4.0"
-
   required_providers {
     external = {
       source  = "hashicorp/external"
@@ -16,7 +14,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.8.1"
+      version = "~> 3.8.0"
     }
   }
 }


### PR DESCRIPTION
Remove required_version from buildingblock/versions.tf files (convention
is to set this only in meshstack_integration.tf) and pin the random
provider with ~> constraint instead of an exact version.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
