### PR TITLE
feature/storage bucket e2e

### DIFF
--- a/.agents/references/stackit-backplane.md
+++ b/.agents/references/stackit-backplane.md
@@ -1,41 +1,53 @@
 ---
-description: STACKIT backplane identity conventions for meshstack-hub modules under modules/stackit/. Covers service account + key pattern, required variables/outputs, provider configuration, meshstack_integration.tf wiring, and the STACKIT backplane checklist.
+description: STACKIT backplane identity conventions for meshstack-hub modules under modules/stackit/. Covers WIF (preferred) and key-based (legacy) patterns, required variables/outputs, provider configuration, meshstack_integration.tf wiring, and the STACKIT backplane checklist.
 ---
 
 # STACKIT Backplane Identity Conventions
 
-STACKIT backplanes **must** use a **service account with a long-lived key** as the automation
-principal for building block execution. The key JSON is provisioned in the backplane and injected
-as a sensitive static input into the building block definition.
+STACKIT backplanes **must** use **Workload Identity Federation (WIF)** as the automation principal
+for building block execution. WIF eliminates long-lived service account keys by exchanging a
+meshStack-issued short-lived OIDC token for a STACKIT access token at runtime.
 
 ## Rationale
 
-- **Self-contained credentials**: The service account and its key are provisioned once in the
-  backplane Terraform module. The key JSON is a single credential that bundles the service account
-  email, key ID, and private key — no extra wiring needed.
-- **Least-privilege**: Each building block gets its own service account with exactly the roles it
-  needs (project-scoped or organization-scoped).
+- **No static secrets**: No service account key JSON to rotate, revoke, or protect.
+- **Least-privilege**: Each building block gets its own service account with exactly the roles it needs.
+- **Short-lived credentials**: OIDC tokens are scoped per building block run and expire quickly.
 - **No provider configuration in backplane**: The backplane module does not include a `provider.tf`.
   Authentication for the backplane itself is configured by the caller (e.g. the platform team running
   `tofu apply` or the integration runtime).
-- **Sensitive by default**: The `service_account_key_json` output is marked `sensitive = true`.
-  meshStack's STATIC input wiring uses the `sensitive.argument.secret_value` field to ensure the
-  key is stored and transmitted as a secret.
 
 <!-- scorecard-checks: stackit_uses_service_account_key -->
 ## Implementation Pattern
 
 ```hcl
-# backplane/main.tf — service account + key + role assignments
+# backplane/main.tf — service account + WIF identity provider + role assignments
 
 resource "stackit_service_account" "backplane" {
   project_id = var.project_id
   name       = "mesh-<service-name>"
 }
 
-resource "stackit_service_account_key" "backplane" {
+resource "stackit_service_account_federated_identity_provider" "backplane" {
+  for_each = { for i, s in var.workload_identity_federation.subjects : tostring(i) => s }
+
   project_id            = var.project_id
   service_account_email = stackit_service_account.backplane.email
+  name                  = "meshstack-${each.key}"
+  issuer                = var.workload_identity_federation.issuer
+
+  assertions = [
+    {
+      item     = "aud"
+      operator = "equals"
+      value    = "sts.accounts.stackit.cloud"
+    },
+    {
+      item     = "sub"
+      operator = "equals"
+      value    = each.value
+    }
+  ]
 }
 
 # Project-scoped role assignment (use this for project-level resources):
@@ -56,13 +68,12 @@ resource "stackit_authorization_organization_role_assignment" "this" {
 <!-- scorecard-checks: stackit_service_account_key_output -->
 ## Backplane Outputs (STACKIT)
 
-Every STACKIT backplane must output the service account key JSON:
+Every STACKIT backplane must output the service account email:
 
 ```hcl
-output "service_account_key_json" {
-  value       = stackit_service_account_key.backplane.json
-  description = "Service account key JSON for authenticating the STACKIT provider in the buildingblock."
-  sensitive   = true
+output "service_account_email" {
+  value       = stackit_service_account.backplane.email
+  description = "Email of the STACKIT service account used by the buildingblock provider via WIF."
 }
 ```
 
@@ -77,6 +88,15 @@ variable "project_id" {
   type        = string
   nullable    = false
   description = "STACKIT project ID where the service account will be created."
+}
+
+variable "workload_identity_federation" {
+  type = object({
+    issuer   = string
+    subjects = list(string)
+  })
+  nullable    = false
+  description = "WIF issuer URL and subject list for the meshStack building block identity provider."
 }
 ```
 
@@ -93,73 +113,104 @@ variable "organization_id" {
 <!-- scorecard-checks: stackit_provider_uses_key -->
 ## Buildingblock Provider Configuration
 
-The buildingblock `provider.tf` must use `service_account_key` for authentication.
-Do **not** use `service_account_email` alone — it does not authenticate.
+The buildingblock `provider.tf` must use `use_oidc = true` and `service_account_email`.
+Do **not** use `service_account_key` — it requires a long-lived secret.
 
 ```hcl
 # buildingblock/provider.tf
 provider "stackit" {
-  service_account_key = var.service_account_key_json
-  # Add any extra provider flags required by the resources (e.g. enable_beta_resources, experiments):
-  # enable_beta_resources = true
-  # experiments           = ["some-feature"]
+  service_account_email = var.service_account_email
+  use_oidc              = true
+  # Token is read from STACKIT_FEDERATED_TOKEN_FILE env var injected by meshStack
 }
 ```
 
 ## Buildingblock Variable
 
 ```hcl
-variable "service_account_key_json" {
+variable "service_account_email" {
   type        = string
   nullable    = false
-  sensitive   = true
-  description = "Service account key JSON for authenticating the STACKIT provider."
+  description = "Email of the STACKIT service account for WIF-based authentication."
 }
 ```
 
-The key JSON bundles the service account email — do **not** add a separate `service_account_email`
-variable when `service_account_key_json` is present.
+The service account email is not sensitive. Do **not** use `sensitive = true` here.
 
 ## `meshstack_integration.tf` Wiring (STACKIT)
 
-Pass the key from the backplane as a **STATIC sensitive** input:
+Retrieve the meshStack WIF issuer and subject via the `meshstack_integrations` data source,
+then pass them to the backplane. Register the WIF env vars as STATIC environment inputs so
+the buildingblock runtime can exchange the token automatically.
 
 ```hcl
+data "meshstack_integrations" "integrations" {}
+
 module "backplane" {
   source = "github.com/meshcloud/meshstack-hub//modules/stackit/<service>/backplane?ref=${var.hub.git_ref}"
 
-  project_id      = var.stackit_project_id
-  # organization_id = var.stackit_organization_id   # if org-scoped roles are needed
+  project_id = var.stackit_project_id
+
+  workload_identity_federation = {
+    issuer = data.meshstack_integrations.integrations.workload_identity_federation.replicator.issuer
+    subjects = [
+      "${trimsuffix(data.meshstack_integrations.integrations.workload_identity_federation.replicator.subject, ":replicator")}:workspace.${var.meshstack.owning_workspace_identifier}.buildingblockdefinition.${meshstack_building_block_definition.this.metadata.uuid}"
+    ]
+  }
 }
 
-# Inside meshstack_backplane_definition version_spec.inputs:
-service_account_key_json = {
-  display_name    = "Service Account Key JSON"
-  description     = "Service account key JSON for authenticating the STACKIT provider."
+# Inside meshstack_building_block_definition version_spec.inputs:
+service_account_email = {
+  display_name    = "Service Account Email"
+  description     = "Email of the STACKIT service account for WIF-based authentication."
   type            = "STRING"
   assignment_type = "STATIC"
-  sensitive = {
-    argument = {
-      secret_value = module.backplane.service_account_key_json
-    }
-  }
+  argument        = jsonencode(module.backplane.service_account_email)
+}
+
+STACKIT_USE_OIDC = {
+  display_name    = "STACKIT Use OIDC"
+  description     = "Enables OIDC-based WIF for the STACKIT provider."
+  type            = "STRING"
+  assignment_type = "STATIC"
+  is_environment  = true
+  argument        = jsonencode("1")
+}
+
+STACKIT_FEDERATED_TOKEN_FILE = {
+  display_name    = "STACKIT Federated Token File"
+  description     = "Path to the WIF token file injected by meshStack."
+  type            = "STRING"
+  assignment_type = "STATIC"
+  is_environment  = true
+  argument        = jsonencode("/var/run/secrets/workload-identity/stackit/token")
 }
 ```
 
+## Provider Version
+
+The `stackit_service_account_federated_identity_provider` resource requires provider version
+`>= 0.95.0`. Pin to `~> 0.98.0` or later in backplane `versions.tf`.
+
 ## What to Avoid
 
-- ❌ `service_account_email` alone in the provider — missing authentication credential
-- ❌ Long-lived `STACKIT_SERVICE_ACCOUNT_TOKEN` injected via env var — not reproducible across runs
-- ❌ Hardcoded key values in integration files
-- ❌ Non-sensitive output for `service_account_key_json` — always mark it `sensitive = true`
+- ❌ `service_account_key` / `stackit_service_account_key` — long-lived secret, no longer needed
+- ❌ `service_account_key_json` output — replace with `service_account_email`
+- ❌ `STACKIT_SERVICE_ACCOUNT_TOKEN` env var — deprecated
+- ❌ Hardcoded `issuer` or `subjects` — always source from `data.meshstack_integrations`
+- ❌ Non-sensitive output for credentials — `service_account_email` is not sensitive, but any key would be
 
 ## Checklist for STACKIT Backplanes
 
 - [ ] `stackit_service_account` resource present
-- [ ] `stackit_service_account_key` resource present (same project as the service account)
+- [ ] `stackit_service_account_federated_identity_provider` resource present (with `for_each` over subjects)
+- [ ] WIF assertions include `aud = "sts.accounts.stackit.cloud"` and `sub = each.value`
 - [ ] Required role assignments present (`stackit_authorization_project_role_assignment` or `stackit_authorization_organization_role_assignment`)
-- [ ] `service_account_key_json` output marked `sensitive = true`
-- [ ] Buildingblock `provider.tf` uses `service_account_key = var.service_account_key_json`
-- [ ] Buildingblock `variables.tf` has `service_account_key_json` (sensitive, nullable = false)
-- [ ] No separate `service_account_email` variable in buildingblock when key is present
-- [ ] `meshstack_integration.tf` wires key via `sensitive.argument.secret_value`
+- [ ] `service_account_email` output present (not sensitive, not `service_account_key_json`)
+- [ ] `workload_identity_federation` variable present (`object({ issuer, subjects })`, `nullable = false`)
+- [ ] Backplane `versions.tf` pins STACKIT provider to `~> 0.98.0` or later
+- [ ] Buildingblock `provider.tf` uses `use_oidc = true` + `service_account_email`
+- [ ] Buildingblock `variables.tf` has `service_account_email` (non-sensitive, `nullable = false`)
+- [ ] No `service_account_key_json` variable or output anywhere
+- [ ] `meshstack_integration.tf` uses `data.meshstack_integrations.integrations` for issuer/subject
+- [ ] `meshstack_integration.tf` wires `STACKIT_USE_OIDC` and `STACKIT_FEDERATED_TOKEN_FILE` as STATIC env var inputs

--- a/.agents/references/stackit-backplane.md
+++ b/.agents/references/stackit-backplane.md
@@ -202,9 +202,14 @@ The `stackit_service_account_federated_identity_provider` resource requires prov
 
 ## Checklist for STACKIT Backplanes
 
+> **Note on token audience**: meshStack issues a single OIDC token at
+> `/var/run/secrets/workload-identity/azure/token` with audience `api://AzureADTokenExchange`.
+> There is no STACKIT-specific token path. The STACKIT provider accepts this token via the
+> `STACKIT_FEDERATED_TOKEN_FILE` env var — the `AzureADTokenExchange` audience is correct.
+
 - [ ] `stackit_service_account` resource present
 - [ ] `stackit_service_account_federated_identity_provider` resource present (with `for_each` over subjects)
-- [ ] WIF assertions include `aud = "sts.accounts.stackit.cloud"` and `sub = each.value`
+- [ ] WIF assertions include `aud = "api://AzureADTokenExchange"` and `sub = each.value`
 - [ ] Required role assignments present (`stackit_authorization_project_role_assignment` or `stackit_authorization_organization_role_assignment`)
 - [ ] `service_account_email` output present (not sensitive, not `service_account_key_json`)
 - [ ] `workload_identity_federation` variable present (`object({ issuer, subjects })`, `nullable = false`)

--- a/.agents/references/stackit-backplane.md
+++ b/.agents/references/stackit-backplane.md
@@ -17,7 +17,7 @@ meshStack-issued short-lived OIDC token for a STACKIT access token at runtime.
   Authentication for the backplane itself is configured by the caller (e.g. the platform team running
   `tofu apply` or the integration runtime).
 
-<!-- scorecard-checks: stackit_uses_service_account_key -->
+<!-- scorecard-checks: stackit_uses_wif, stackit_no_sa_key -->
 ## Implementation Pattern
 
 ```hcl
@@ -65,7 +65,7 @@ resource "stackit_authorization_organization_role_assignment" "this" {
 }
 ```
 
-<!-- scorecard-checks: stackit_service_account_key_output -->
+<!-- scorecard-checks: stackit_sa_email_output -->
 ## Backplane Outputs (STACKIT)
 
 Every STACKIT backplane must output the service account email:
@@ -110,7 +110,7 @@ variable "organization_id" {
 }
 ```
 
-<!-- scorecard-checks: stackit_provider_uses_key -->
+<!-- scorecard-checks: stackit_provider_oidc -->
 ## Buildingblock Provider Configuration
 
 The buildingblock `provider.tf` must use `use_oidc = true` and `service_account_email`.
@@ -201,11 +201,6 @@ The `stackit_service_account_federated_identity_provider` resource requires prov
 - ❌ Non-sensitive output for credentials — `service_account_email` is not sensitive, but any key would be
 
 ## Checklist for STACKIT Backplanes
-
-> **Note on token audience**: meshStack issues a single OIDC token at
-> `/var/run/secrets/workload-identity/azure/token` with audience `api://AzureADTokenExchange`.
-> There is no STACKIT-specific token path. The STACKIT provider accepts this token via the
-> `STACKIT_FEDERATED_TOKEN_FILE` env var — the `AzureADTokenExchange` audience is correct.
 
 - [ ] `stackit_service_account` resource present
 - [ ] `stackit_service_account_federated_identity_provider` resource present (with `for_each` over subjects)

--- a/.agents/references/stackit-backplane.md
+++ b/.agents/references/stackit-backplane.md
@@ -40,7 +40,7 @@ resource "stackit_service_account_federated_identity_provider" "backplane" {
     {
       item     = "aud"
       operator = "equals"
-      value    = "sts.accounts.stackit.cloud"
+      value    = "api://AzureADTokenExchange"
     },
     {
       item     = "sub"
@@ -183,7 +183,7 @@ STACKIT_FEDERATED_TOKEN_FILE = {
   type            = "STRING"
   assignment_type = "STATIC"
   is_environment  = true
-  argument        = jsonencode("/var/run/secrets/workload-identity/stackit/token")
+  argument        = jsonencode("/var/run/secrets/workload-identity/azure/token")
 }
 ```
 

--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -199,6 +199,68 @@ tofu init -upgrade -var-file=/tmp/test-vars.tfvars.json
 tofu test -var-file=/tmp/test-vars.tfvars.json -var="my_secret=value"
 ```
 
+### Advanced Debugging
+
+#### Debugging with `tofu apply` (bypass `tofu test` teardown)
+
+When iterating on a failing building block run, it's faster to use `tofu apply` directly
+in the `e2e/` directory instead of `tofu test`. This bypasses the test framework's automatic
+teardown so you can inspect the deployed state:
+
+```bash
+cd modules/<provider>/<service>/e2e
+tofu init -upgrade -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
+tofu apply -auto-approve -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
+```
+
+After debugging, **always destroy manually**:
+
+```bash
+tofu destroy -auto-approve -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
+```
+
+Do not leave apply state behind — it will block subsequent `tofu test` runs because the BBD
+already exists under the same workspace.
+
+#### Fetching building block run logs
+
+Use the `tools/debug/get-bb-run-logs.mjs` helper to fetch step-by-step Terraform logs for a
+building block run without manual curl calls:
+
+```bash
+# From meshstack-hub after: source ../meshstack-smoke-test/setup-env.sh
+BB_UUID="<uuid from state or errored_test.tfstate>"
+node tools/debug/get-bb-run-logs.mjs "$BB_UUID"
+```
+
+To get the UUID from an errored test state:
+```bash
+tofu state show -state=errored_test.tfstate 'meshstack_building_block_v2.this' | grep uuid
+```
+
+#### Provider override for local meshstack provider binary
+
+`source setup-override-provider.sh` in `meshstack-smoke-test` must be run from the
+`meshstack-smoke-test` directory itself, not from the hub repo. When sourced from a different
+working directory, the script correctly resolves its own path via `BASH_SOURCE[0]`.
+
+After sourcing, export the config file to affect all tofu invocations in the current shell:
+```bash
+cd /path/to/meshstack-smoke-test
+source setup-override-provider.sh
+# TF_CLI_CONFIG_FILE is now exported — all tofu calls in this shell use the local binary
+```
+
+---
+
+## Fetching run logs from the meshStack API
+
+Use `tools/debug/get-bb-run-logs.mjs` — it handles auth, run listing, and log fetching in one
+command. See the [Advanced Debugging](#advanced-debugging) section above for usage.
+
+The `systemMessage` of the `Run Terraform Apply` step contains the full `tofu apply` output,
+including the plan diff and any provider errors.
+
 ---
 
 ## Checklist for New E2E Tests

--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -166,8 +166,8 @@ its output as a temp `.tfvars.json`, then runs `tofu test` in the module's `e2e/
 
 ## Debugging
 
-**Hub changes must be pushed before running.** The runner resolves `hub_git_ref` from the current
-commit SHA and verifies it exists on a remote branch:
+### Hub changes must be pushed before running
+The runner resolves `hub_git_ref` from the current commit SHA and verifies it exists on a remote branch:
 
 ```
 ERROR: Hub commit <sha> has not been pushed to any remote branch.
@@ -176,8 +176,10 @@ ERROR: Hub commit <sha> has not been pushed to any remote branch.
 Fix: push your branch first. Uncommitted local changes only produce a warning — the test still runs
 against the committed SHA. Only the `e2e/` directory itself is executed from local disk.
 
-**Errored test state.** If `tofu test` fails mid-apply, OpenTofu writes `e2e/errored_test.tfstate`.
-Clean up:
+### Errored test state
+
+If `tofu test` fails mid-apply, OpenTofu writes `e2e/errored_test.tfstate`.
+Interacting with the test state is useful for manually cleaning up cloud resources when tofu fails to do it:
 
 ```bash
 cd modules/<provider>/<service>/e2e
@@ -185,51 +187,20 @@ tofu state list -state=errored_test.tfstate
 rm errored_test.tfstate   # after manual cleanup if needed
 ```
 
-**Manual run (bypass the runner).** Useful for passing extra `-var` flags or iterating quickly:
+### Fetching building block run logs
 
-```bash
-# From meshstack-smoke-test: produce the var-file
-tofu -chdir=modules/test_context apply -auto-approve -var="hub_dir=$(pwd)/../meshstack-hub"
-ctx=$(tofu -chdir=modules/test_context output -json test_context)
-printf '{"test_context":%s}\n' "$ctx" > /tmp/test-vars.tfvars.json
+The most likely cause of a test failure is a building block run failure, manifesting as an error message like this
 
-# From meshstack-hub: run test directly
-cd modules/<provider>/<service>/e2e
-tofu init -upgrade -var-file=/tmp/test-vars.tfvars.json
-tofu test -var-file=/tmp/test-vars.tfvars.json -var="my_secret=value"
-```
-
-### Advanced Debugging
-
-#### Debugging with `tofu apply` (bypass `tofu test` teardown)
-
-When iterating on a failing building block run, it's faster to use `tofu apply` directly
-in the `e2e/` directory instead of `tofu test`. This bypasses the test framework's automatic
-teardown so you can inspect the deployed state:
-
-```bash
-cd modules/<provider>/<service>/e2e
-tofu init -upgrade -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
-tofu apply -auto-approve -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
-```
-
-After debugging, **always destroy manually**:
-
-```bash
-tofu destroy -auto-approve -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
-```
-
-Do not leave apply state behind — it will block subsequent `tofu test` runs because the BBD
-already exists under the same workspace.
-
-#### Fetching building block run logs
+> Failed to await building block creation
+> item in failed state: building block 97cc733e-9611-460a-8bbf-d930466cfc94
+> reached FAILED state during creation, check the building block run logs in meshStack
 
 Use the `tools/debug/get-bb-run-logs.mjs` helper to fetch step-by-step Terraform logs for a
 building block run without manual curl calls:
 
 ```bash
 # From meshstack-hub after: source ../meshstack-smoke-test/setup-env.sh
-BB_UUID="<uuid from state or errored_test.tfstate>"
+BB_UUID="<uuid from log or errored_test.tfstate>"
 node tools/debug/get-bb-run-logs.mjs "$BB_UUID"
 ```
 
@@ -238,7 +209,39 @@ To get the UUID from an errored test state:
 tofu state show -state=errored_test.tfstate 'meshstack_building_block_v2.this' | grep uuid
 ```
 
-#### Provider override for local meshstack provider binary
+
+## Advanced Debugging
+
+### Debugging with `tofu apply` (bypass `tofu test` teardown)
+
+When iterating on a new building block, it's sometimes faster to use `tofu apply` directly
+in the `e2e/` directory instead of `tofu test`. This bypasses the test framework's automatic
+teardown and you can more quickly iterate on the deployed state, making changes across `meshstack_integration.tf`,
+the `backplane` and `buildingblock` module as well as the test assertions themselves.
+
+Step 1, produce the test_context var file
+```bash
+# From meshstack-smoke-test: produce the var-file
+tofu -chdir=modules/test_context apply -auto-approve -var="hub_dir=$(pwd)/../meshstack-hub"
+ctx=$(tofu -chdir=modules/test_context output -json test_context)
+printf '{"test_context":%s}\n' "$ctx" > /tmp/test-vars.tfvars.json
+
+# From meshstack-hub: run module directly directly
+cd modules/<provider>/<service>/e2e
+tofu init -upgrade -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
+tofu apply -auto-approve -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
+```
+
+After debugging, **always destroy explicitly**:
+
+```bash
+tofu destroy -auto-approve -var-file=/tmp/test-vars.tfvars.json -var="my_secret=$SECRET"
+```
+
+### Provider override for local meshstack provider binary
+
+When testing against pre-release versions of the meshStack terraform provider is required, ie. due to impending breaking
+changes or using pre-release features:
 
 `source setup-override-provider.sh` in `meshstack-smoke-test` must be run from the
 `meshstack-smoke-test` directory itself, not from the hub repo. When sourced from a different
@@ -250,16 +253,6 @@ cd /path/to/meshstack-smoke-test
 source setup-override-provider.sh
 # TF_CLI_CONFIG_FILE is now exported — all tofu calls in this shell use the local binary
 ```
-
----
-
-## Fetching run logs from the meshStack API
-
-Use `tools/debug/get-bb-run-logs.mjs` — it handles auth, run listing, and log fetching in one
-command. See the [Advanced Debugging](#advanced-debugging) section above for usage.
-
-The `systemMessage` of the `Run Terraform Apply` step contains the full `tofu apply` output,
-including the plan diff and any provider errors.
 
 ---
 

--- a/ci/validate_modules.sh
+++ b/ci/validate_modules.sh
@@ -115,16 +115,16 @@ fi
 
 modules_glob="$modules_path/*/*/buildingblock"
 
-for readme_file in $(find $modules_glob -name 'README.md'); do
+for readme_file in $(find $modules_glob -name 'README.md' -not -path '*/.terraform/*'); do
 	check_readme_format "$readme_file"
 done
 
-for png_file in $(find $modules_glob -name '*.png'); do
+for png_file in $(find $modules_glob -name '*.png' -not -path '*/.terraform/*'); do
 	check_png_naming "$png_file"
 	check_png_minimization "$png_file"
 done
 
-for buildingblock_dir in $(find $modules_glob -type d -name 'buildingblock'); do
+for buildingblock_dir in $(find $modules_glob -type d -name 'buildingblock' -not -path '*/.terraform/*'); do
 	check_terraform_files "$buildingblock_dir"
 done
 

--- a/modules/stackit/storage-bucket/backplane/README.md
+++ b/modules/stackit/storage-bucket/backplane/README.md
@@ -60,6 +60,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | STACKIT project ID where Object Storage buckets will be created. | `string` | n/a | yes |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | Name of the service account created in the STACKIT project. Override when deploying multiple backplane instances in the same project. | `string` | `"mesh-storage-bucket"` | no |
 | <a name="input_workload_identity_federation"></a> [workload\_identity\_federation](#input\_workload\_identity\_federation) | WIF issuer URL and subject list for the meshStack building block identity provider. | <pre>object({<br/>    issuer   = string<br/>    subjects = list(string)<br/>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/stackit/storage-bucket/backplane/README.md
+++ b/modules/stackit/storage-bucket/backplane/README.md
@@ -1,7 +1,9 @@
 # STACKIT Storage Bucket – Backplane
 
 This module sets up the shared backplane configuration for the STACKIT Storage Bucket building block.
-It creates a dedicated service account with least-privilege permissions in the target STACKIT project:
+It creates a dedicated service account with least-privilege permissions in the target STACKIT project
+and registers a Workload Identity Federation (WIF) provider so meshStack can authenticate without
+long-lived keys:
 
 - **`object-storage.admin`** — allows managing Object Storage buckets, credentials groups, and credentials.
 - **`object-storage.service-account-admin`** — allows creating per-bucket credentials groups and credentials from the building block.
@@ -11,8 +13,9 @@ to apply bucket policies via the S3 API.
 
 ## Prerequisites
 
-- A STACKIT service account with permissions to manage service accounts and Object Storage in the target project.
+- A STACKIT service account with permissions to manage service accounts, IAM, and Object Storage in the target project.
 - The STACKIT project must already exist.
+- A meshStack installation with Workload Identity Federation enabled (provides `issuer` and `subject`).
 
 ## Usage
 
@@ -21,6 +24,11 @@ module "storage_bucket_backplane" {
   source = "./backplane"
 
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+  workload_identity_federation = {
+    issuer   = data.meshstack_integrations.integrations.workload_identity_federation.replicator.issuer
+    subjects = ["<meshstack-building-block-subject>"]
+  }
 }
 ```
 
@@ -30,7 +38,7 @@ module "storage_bucket_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | ~> 0.88.0 |
+| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | ~> 0.98.0 |
 
 ## Modules
 
@@ -45,13 +53,14 @@ No modules.
 | [stackit_objectstorage_credential.admin](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
 | [stackit_objectstorage_credentials_group.admin](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
 | [stackit_service_account.building_block](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/service_account) | resource |
-| [stackit_service_account_key.building_block](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/service_account_key) | resource |
+| [stackit_service_account_federated_identity_provider.building_block](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/service_account_federated_identity_provider) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | STACKIT project ID where Object Storage buckets will be created. | `string` | n/a | yes |
+| <a name="input_workload_identity_federation"></a> [workload\_identity\_federation](#input\_workload\_identity\_federation) | WIF issuer URL and subject list for the meshStack building block identity provider. | <pre>object({<br/>    issuer   = string<br/>    subjects = list(string)<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 
@@ -61,5 +70,5 @@ No modules.
 | <a name="output_admin_s3_access_key"></a> [admin\_s3\_access\_key](#output\_admin\_s3\_access\_key) | S3 access key for the admin credentials group used to manage bucket policies. |
 | <a name="output_admin_s3_secret_access_key"></a> [admin\_s3\_secret\_access\_key](#output\_admin\_s3\_secret\_access\_key) | S3 secret access key for the admin credentials group used to manage bucket policies. |
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | STACKIT project ID for Object Storage bucket creation. |
-| <a name="output_service_account_key_json"></a> [service\_account\_key\_json](#output\_service\_account\_key\_json) | Service account key JSON for authenticating the STACKIT provider in the buildingblock. |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the STACKIT service account used by the buildingblock provider via WIF. |
 <!-- END_TF_DOCS -->

--- a/modules/stackit/storage-bucket/backplane/main.tf
+++ b/modules/stackit/storage-bucket/backplane/main.tf
@@ -15,7 +15,7 @@ resource "stackit_service_account_federated_identity_provider" "building_block" 
     {
       item     = "aud"
       operator = "equals"
-      value    = "sts.accounts.stackit.cloud"
+      value    = "api://AzureADTokenExchange"
     },
     {
       item     = "sub"

--- a/modules/stackit/storage-bucket/backplane/main.tf
+++ b/modules/stackit/storage-bucket/backplane/main.tf
@@ -1,6 +1,6 @@
 resource "stackit_service_account" "building_block" {
   project_id = var.project_id
-  name       = "mesh-storage-bucket"
+  name       = var.service_account_name
 }
 
 resource "stackit_service_account_federated_identity_provider" "building_block" {

--- a/modules/stackit/storage-bucket/backplane/main.tf
+++ b/modules/stackit/storage-bucket/backplane/main.tf
@@ -3,9 +3,26 @@ resource "stackit_service_account" "building_block" {
   name       = "mesh-storage-bucket"
 }
 
-resource "stackit_service_account_key" "building_block" {
+resource "stackit_service_account_federated_identity_provider" "building_block" {
+  for_each = { for i, s in var.workload_identity_federation.subjects : tostring(i) => s }
+
   project_id            = var.project_id
   service_account_email = stackit_service_account.building_block.email
+  name                  = "meshstack-${each.key}"
+  issuer                = var.workload_identity_federation.issuer
+
+  assertions = [
+    {
+      item     = "aud"
+      operator = "equals"
+      value    = "sts.accounts.stackit.cloud"
+    },
+    {
+      item     = "sub"
+      operator = "equals"
+      value    = each.value
+    }
+  ]
 }
 
 resource "stackit_authorization_project_role_assignment" "object_storage" {

--- a/modules/stackit/storage-bucket/backplane/outputs.tf
+++ b/modules/stackit/storage-bucket/backplane/outputs.tf
@@ -3,10 +3,9 @@ output "project_id" {
   description = "STACKIT project ID for Object Storage bucket creation."
 }
 
-output "service_account_key_json" {
-  value       = stackit_service_account_key.building_block.json
-  description = "Service account key JSON for authenticating the STACKIT provider in the buildingblock."
-  sensitive   = true
+output "service_account_email" {
+  value       = stackit_service_account.building_block.email
+  description = "Email of the STACKIT service account used by the buildingblock provider via WIF."
 }
 
 output "admin_s3_access_key" {

--- a/modules/stackit/storage-bucket/backplane/variables.tf
+++ b/modules/stackit/storage-bucket/backplane/variables.tf
@@ -3,3 +3,12 @@ variable "project_id" {
   nullable    = false
   description = "STACKIT project ID where Object Storage buckets will be created."
 }
+
+variable "workload_identity_federation" {
+  type = object({
+    issuer   = string
+    subjects = list(string)
+  })
+  nullable    = false
+  description = "WIF issuer URL and subject list for the meshStack building block identity provider."
+}

--- a/modules/stackit/storage-bucket/backplane/variables.tf
+++ b/modules/stackit/storage-bucket/backplane/variables.tf
@@ -4,6 +4,13 @@ variable "project_id" {
   description = "STACKIT project ID where Object Storage buckets will be created."
 }
 
+variable "service_account_name" {
+  type        = string
+  default     = "mesh-storage-bucket"
+  nullable    = false
+  description = "Name of the service account created in the STACKIT project. Override when deploying multiple backplane instances in the same project."
+}
+
 variable "workload_identity_federation" {
   type = object({
     issuer   = string

--- a/modules/stackit/storage-bucket/backplane/versions.tf
+++ b/modules/stackit/storage-bucket/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "stackitcloud/stackit"
-      version = "~> 0.88.0"
+      version = "~> 0.98.0"
     }
   }
 }

--- a/modules/stackit/storage-bucket/buildingblock/README.md
+++ b/modules/stackit/storage-bucket/buildingblock/README.md
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_admin_s3_secret_access_key"></a> [admin\_s3\_secret\_access\_key](#input\_admin\_s3\_secret\_access\_key) | S3 secret access key for the admin credentials group used to apply bucket policies. | `string` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the Object Storage bucket. Must be DNS-conformant. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | STACKIT project ID where the bucket will be created. | `string` | n/a | yes |
-| <a name="input_service_account_key_json"></a> [service\_account\_key\_json](#input\_service\_account\_key\_json) | Service account key JSON for authenticating the STACKIT provider. | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email of the STACKIT service account for WIF-based authentication. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/stackit/storage-bucket/buildingblock/provider.tf
+++ b/modules/stackit/storage-bucket/buildingblock/provider.tf
@@ -1,5 +1,6 @@
 provider "stackit" {
-  service_account_key = var.service_account_key_json
+  service_account_email = var.service_account_email
+  use_oidc              = true
 }
 
 provider "aws" {

--- a/modules/stackit/storage-bucket/buildingblock/variables.tf
+++ b/modules/stackit/storage-bucket/buildingblock/variables.tf
@@ -6,11 +6,10 @@ variable "project_id" {
   description = "STACKIT project ID where the bucket will be created."
 }
 
-variable "service_account_key_json" {
+variable "service_account_email" {
   type        = string
   nullable    = false
-  sensitive   = true
-  description = "Service account key JSON for authenticating the STACKIT provider."
+  description = "Email of the STACKIT service account for WIF-based authentication."
 }
 
 variable "admin_s3_access_key" {

--- a/modules/stackit/storage-bucket/e2e/main.tf
+++ b/modules/stackit/storage-bucket/e2e/main.tf
@@ -38,7 +38,7 @@ module "stackit_storage_bucket" {
   }
 
   stackit_project_id           = var.test_context.fixtures.stackit.project_id
-  stackit_service_account_name = "mesh-storage-bucket-${var.test_context.name_suffix}"
+  stackit_service_account_name = "msb-${var.test_context.name_suffix}"
 }
 
 resource "meshstack_building_block_v2" "this" {

--- a/modules/stackit/storage-bucket/e2e/main.tf
+++ b/modules/stackit/storage-bucket/e2e/main.tf
@@ -1,0 +1,47 @@
+variable "test_context" {
+  type = object({
+    hub_git_ref = string
+    workspace   = string
+    project     = string
+    name_suffix = string
+
+    fixtures = object({
+      stackit = object({
+        project_id     = string
+        mesh_tenant_id = string
+      })
+    })
+  })
+  nullable = false
+}
+
+module "stackit_storage_bucket" {
+  source = "../"
+  meshstack = {
+    owning_workspace_identifier = var.test_context.workspace
+    tags                        = {}
+  }
+  hub = {
+    git_ref   = var.test_context.hub_git_ref
+    bbd_draft = true
+  }
+
+  stackit_project_id = var.test_context.fixtures.stackit.project_id
+}
+
+resource "meshstack_building_block_v2" "this" {
+  wait_for_completion = true
+  spec = {
+    building_block_definition_version_ref = module.stackit_storage_bucket.building_block_definition.version_ref
+
+    display_name = "smoke-test-stackit-storage-bucket-${var.test_context.name_suffix}"
+    target_ref = {
+      kind = "meshWorkspace"
+      name = var.test_context.workspace
+    }
+
+    inputs = {
+      bucket_name = { value_string = "smoke-test-bucket-${var.test_context.name_suffix}" }
+    }
+  }
+}

--- a/modules/stackit/storage-bucket/e2e/main.tf
+++ b/modules/stackit/storage-bucket/e2e/main.tf
@@ -1,3 +1,14 @@
+variable "stackit_service_account_key" {
+  type      = string
+  nullable  = false
+  sensitive = true
+}
+
+provider "stackit" {
+  service_account_key = var.stackit_service_account_key
+  experiments         = ["iam"]
+}
+
 variable "test_context" {
   type = object({
     hub_git_ref = string

--- a/modules/stackit/storage-bucket/e2e/main.tf
+++ b/modules/stackit/storage-bucket/e2e/main.tf
@@ -37,7 +37,8 @@ module "stackit_storage_bucket" {
     bbd_draft = true
   }
 
-  stackit_project_id = var.test_context.fixtures.stackit.project_id
+  stackit_project_id           = var.test_context.fixtures.stackit.project_id
+  stackit_service_account_name = "mesh-storage-bucket-${var.test_context.name_suffix}"
 }
 
 resource "meshstack_building_block_v2" "this" {

--- a/modules/stackit/storage-bucket/e2e/terraform.tf
+++ b/modules/stackit/storage-bucket/e2e/terraform.tf
@@ -5,5 +5,9 @@ terraform {
     meshstack = {
       source = "meshcloud/meshstack"
     }
+    stackit = {
+      source  = "stackitcloud/stackit"
+      version = "~> 0.88.0"
+    }
   }
 }

--- a/modules/stackit/storage-bucket/e2e/terraform.tf
+++ b/modules/stackit/storage-bucket/e2e/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    meshstack = {
+      source = "meshcloud/meshstack"
+    }
+  }
+}

--- a/modules/stackit/storage-bucket/e2e/terraform.tf
+++ b/modules/stackit/storage-bucket/e2e/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     stackit = {
       source  = "stackitcloud/stackit"
-      version = "~> 0.88.0"
+      version = "~> 0.98.0"
     }
   }
 }

--- a/modules/stackit/storage-bucket/e2e/tests/building_block_stackit_storage-bucket_hub.tftest.hcl
+++ b/modules/stackit/storage-bucket/e2e/tests/building_block_stackit_storage-bucket_hub.tftest.hcl
@@ -1,0 +1,26 @@
+run "building_block_stackit_storage_bucket_hub" {
+  assert {
+    condition     = meshstack_building_block_v2.this.status.status == "SUCCEEDED"
+    error_message = "stackit storage-bucket hub building block expected SUCCEEDED, got ${meshstack_building_block_v2.this.status.status}"
+  }
+
+  assert {
+    condition     = meshstack_building_block_v2.this.status.outputs["bucket_name"].value_string == "smoke-test-bucket-${var.test_context.name_suffix}"
+    error_message = "stackit storage-bucket hub building block expected bucket_name to be 'smoke-test-bucket-${var.test_context.name_suffix}', got ${meshstack_building_block_v2.this.status.outputs["bucket_name"].value_string}"
+  }
+
+  assert {
+    condition     = strcontains(meshstack_building_block_v2.this.status.outputs["bucket_url_path_style"].value_string, "smoke-test-bucket-${var.test_context.name_suffix}")
+    error_message = "stackit storage-bucket hub building block expected bucket_url_path_style to contain bucket name, got ${meshstack_building_block_v2.this.status.outputs["bucket_url_path_style"].value_string}"
+  }
+
+  assert {
+    condition     = strcontains(meshstack_building_block_v2.this.status.outputs["bucket_url_path_style"].value_string, "object.storage.eu01.onstackit.cloud")
+    error_message = "stackit storage-bucket hub building block expected bucket_url_path_style to contain STACKIT domain, got ${meshstack_building_block_v2.this.status.outputs["bucket_url_path_style"].value_string}"
+  }
+
+  assert {
+    condition     = length(meshstack_building_block_v2.this.status.outputs["s3_access_key"].value_string) > 0
+    error_message = "stackit storage-bucket hub building block expected non-empty s3_access_key"
+  }
+}

--- a/modules/stackit/storage-bucket/meshstack_integration.tf
+++ b/modules/stackit/storage-bucket/meshstack_integration.tf
@@ -3,6 +3,12 @@ variable "stackit_project_id" {
   description = "STACKIT project ID where Object Storage buckets will be created."
 }
 
+variable "stackit_service_account_name" {
+  type        = string
+  default     = null
+  description = "Name of the backplane service account. Defaults to 'mesh-storage-bucket'. Override when deploying multiple backplane instances in the same STACKIT project."
+}
+
 variable "meshstack" {
   type = object({
     owning_workspace_identifier = string
@@ -36,7 +42,8 @@ data "meshstack_integrations" "integrations" {}
 module "backplane" {
   source = "github.com/meshcloud/meshstack-hub//modules/stackit/storage-bucket/backplane?ref=${var.hub.git_ref}"
 
-  project_id = var.stackit_project_id
+  project_id           = var.stackit_project_id
+  service_account_name = coalesce(var.stackit_service_account_name, "mesh-storage-bucket")
 
   workload_identity_federation = {
     issuer = data.meshstack_integrations.integrations.workload_identity_federation.replicator.issuer

--- a/modules/stackit/storage-bucket/meshstack_integration.tf
+++ b/modules/stackit/storage-bucket/meshstack_integration.tf
@@ -31,10 +31,19 @@ output "building_block_definition" {
   }
 }
 
+data "meshstack_integrations" "integrations" {}
+
 module "backplane" {
   source = "github.com/meshcloud/meshstack-hub//modules/stackit/storage-bucket/backplane?ref=${var.hub.git_ref}"
 
   project_id = var.stackit_project_id
+
+  workload_identity_federation = {
+    issuer = data.meshstack_integrations.integrations.workload_identity_federation.replicator.issuer
+    subjects = [
+      "${trimsuffix(data.meshstack_integrations.integrations.workload_identity_federation.replicator.subject, ":replicator")}:workspace.${var.meshstack.owning_workspace_identifier}.buildingblockdefinition.${meshstack_building_block_definition.this.metadata.uuid}"
+    ]
+  }
 }
 
 resource "meshstack_building_block_definition" "this" {
@@ -107,16 +116,30 @@ resource "meshstack_building_block_definition" "this" {
         argument        = jsonencode(module.backplane.project_id)
       }
 
-      service_account_key_json = {
-        display_name    = "Service Account Key JSON"
-        description     = "Service account key JSON for authenticating the STACKIT provider."
+      service_account_email = {
+        display_name    = "Service Account Email"
+        description     = "Email of the STACKIT service account for WIF-based authentication."
         type            = "STRING"
         assignment_type = "STATIC"
-        sensitive = {
-          argument = {
-            secret_value = module.backplane.service_account_key_json
-          }
-        }
+        argument        = jsonencode(module.backplane.service_account_email)
+      }
+
+      STACKIT_USE_OIDC = {
+        display_name    = "STACKIT Use OIDC"
+        description     = "Enables OIDC-based WIF for the STACKIT provider."
+        type            = "STRING"
+        assignment_type = "STATIC"
+        is_environment  = true
+        argument        = jsonencode("1")
+      }
+
+      STACKIT_FEDERATED_TOKEN_FILE = {
+        display_name    = "STACKIT Federated Token File"
+        description     = "Path to the WIF token file injected by meshStack."
+        type            = "STRING"
+        assignment_type = "STATIC"
+        is_environment  = true
+        argument        = jsonencode("/var/run/secrets/workload-identity/stackit/token")
       }
 
       admin_s3_access_key = {

--- a/modules/stackit/storage-bucket/meshstack_integration.tf
+++ b/modules/stackit/storage-bucket/meshstack_integration.tf
@@ -146,7 +146,7 @@ resource "meshstack_building_block_definition" "this" {
         type            = "STRING"
         assignment_type = "STATIC"
         is_environment  = true
-        argument        = jsonencode("/var/run/secrets/workload-identity/stackit/token")
+        argument        = jsonencode("/var/run/secrets/workload-identity/azure/token")
       }
 
       admin_s3_access_key = {

--- a/tools/debug/get-bb-run-logs.mjs
+++ b/tools/debug/get-bb-run-logs.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// get-bb-run-logs.mjs — fetch step-by-step building block run logs from meshStack
+// No external npm dependencies required (uses Node 18+ built-in fetch).
+//
+// Usage:
+//   node tools/debug/get-bb-run-logs.mjs <building-block-uuid>
+//
+// Prerequisites: source setup-env.sh in meshstack-smoke-test first to export
+//   MESHSTACK_ENDPOINT, MESHSTACK_API_KEY, and MESHSTACK_API_SECRET.
+
+// ── color helpers ─────────────────────────────────────────────────────────────
+
+const tty = process.stdout.isTTY;
+const esc = tty ? (code, s) => `\x1b[${code}m${s}\x1b[0m` : (_, s) => s;
+
+const c = {
+  bold:   s => esc('1',    s),
+  dim:    s => esc('2',    s),
+  red:    s => esc('31',   s),
+  green:  s => esc('32',   s),
+  yellow: s => esc('33',   s),
+  cyan:   s => esc('36',   s),
+  error:  s => esc('1;31', s),
+  warn:   s => esc('33',   s),
+  ok:     s => esc('32',   s),
+  header: s => esc('1;34', s),
+};
+
+function log(msg)  { console.log(msg); }
+function err(msg)  { console.error(c.error('ERROR ') + msg); }
+function warn(msg) { console.warn(c.warn('WARN  ') + msg); }
+
+// ── argument / environment checks ─────────────────────────────────────────────
+
+const BB_UUID = process.argv[2];
+
+if (!BB_UUID) {
+  console.error(c.bold('Usage: node tools/debug/get-bb-run-logs.mjs <building-block-uuid>'));
+  process.exit(1);
+}
+
+const { MESHSTACK_ENDPOINT, MESHSTACK_API_KEY, MESHSTACK_API_SECRET } = process.env;
+
+if (!MESHSTACK_ENDPOINT || !MESHSTACK_API_KEY || !MESHSTACK_API_SECRET) {
+  err('MESHSTACK_ENDPOINT, MESHSTACK_API_KEY and MESHSTACK_API_SECRET must be set.');
+  err('Run: source ../meshstack-smoke-test/setup-env.sh');
+  process.exit(1);
+}
+
+// ── meshStack helpers ─────────────────────────────────────────────────────────
+
+const BB_RUN_ACCEPT = 'application/vnd.meshcloud.api.meshbuildingblockrun.v1.hal+json';
+
+async function meshLogin() {
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: MESHSTACK_API_KEY,
+    client_secret: MESHSTACK_API_SECRET,
+  });
+  const res = await fetch(`${MESHSTACK_ENDPOINT}/api/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`meshStack login failed: ${res.status} ${await res.text()}`);
+  const { access_token } = await res.json();
+  return access_token;
+}
+
+async function meshGet(token, url, accept) {
+  const fullUrl = url.startsWith('http') ? url : `${MESHSTACK_ENDPOINT}${url}`;
+  const res = await fetch(fullUrl, {
+    headers: { Authorization: `Bearer ${token}`, Accept: accept },
+  });
+  if (!res.ok) throw new Error(`GET ${url} failed: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  log(c.dim(`Authenticating with meshStack at ${MESHSTACK_ENDPOINT}...`));
+  const token = await meshLogin();
+
+  log(c.dim(`Fetching runs for building block ${BB_UUID}...`));
+  const runsData = await meshGet(
+    token,
+    `/api/meshobjects/meshbuildingblockruns?buildingBlockUuid=${BB_UUID}`,
+    BB_RUN_ACCEPT,
+  );
+
+  const runs = runsData._embedded?.meshBuildingBlockRuns ?? [];
+
+  if (runs.length === 0) {
+    warn(`No runs found for building block UUID: ${BB_UUID}`);
+    process.exit(0);
+  }
+
+  log(c.bold(`\nFound ${runs.length} run(s) for building block ${BB_UUID}\n`));
+
+  let anyFailed = false;
+
+  for (const run of runs) {
+    const runNumber = run.spec?.runNumber ?? '?';
+    const status    = run.status?.status ?? 'UNKNOWN';
+    const logsHref  = run._links?.downloadLogs?.href;
+
+    const statusColor = status === 'SUCCEEDED' ? c.ok(status)
+                      : status === 'FAILED'    ? c.error(status)
+                      : c.yellow(status);
+
+    log(c.header(`=== Run #${runNumber} [${statusColor}] ===`));
+
+    if (status === 'FAILED') anyFailed = true;
+
+    if (!logsHref) {
+      warn(`  No downloadLogs link available for run #${runNumber}`);
+      continue;
+    }
+
+    let logsData;
+    try {
+      logsData = await meshGet(token, logsHref, BB_RUN_ACCEPT);
+    } catch (e) {
+      err(`  Failed to fetch logs for run #${runNumber}: ${e.message}`);
+      continue;
+    }
+
+    const steps = logsData.steps ?? [];
+    if (steps.length === 0) {
+      log(c.dim('  (no steps)'));
+      continue;
+    }
+
+    for (const step of steps) {
+      const stepName   = step.displayName ?? step.name ?? '(unnamed step)';
+      const stepStatus = step.status ?? 'UNKNOWN';
+      const msg        = step.systemMessage ?? '';
+
+      const stepColor = stepStatus === 'SUCCEEDED' ? c.ok(stepStatus)
+                      : stepStatus === 'FAILED'    ? c.error(stepStatus)
+                      : c.yellow(stepStatus);
+
+      log(c.bold(`--- ${stepName} [${stepColor}] ---`));
+      if (msg) {
+        log(msg);
+      } else {
+        log(c.dim('  (no system message)'));
+      }
+    }
+
+    log('');
+  }
+
+  process.exit(anyFailed ? 1 : 0);
+}
+
+main().catch(e => {
+  err(e.message);
+  process.exit(1);
+});

--- a/tools/scorecard/scorecard.mjs
+++ b/tools/scorecard/scorecard.mjs
@@ -41,6 +41,13 @@ const CATEGORIES = {
     appliesTo: (mod) =>
       mod.provider === "azure" && existsSync(join(mod.path, "backplane")),
   },
+  stackit_backplane: {
+    id: "stackit_backplane",
+    name: "STACKIT Backplane",
+    description: "STACKIT WIF-based automation principal conventions",
+    appliesTo: (mod) =>
+      mod.provider === "stackit" && existsSync(join(mod.path, "backplane")),
+  },
   testing: {
     id: "testing",
     name: "Testing",
@@ -435,6 +442,68 @@ const detectors = [
     },
   },
 
+  // ─── STACKIT Backplane ──────────────────────────────────────────────────
+  {
+    id: "stackit_uses_wif",
+    category: "stackit_backplane",
+    name: "Uses stackit_service_account_federated_identity_provider",
+    emoji: "🔐",
+    fn: (mod) => {
+      const allTf = readAllBackplaneTf(mod);
+      if (!allTf) return { pass: false, detail: "no backplane tf files" };
+      return {
+        pass: /resource\s+"stackit_service_account_federated_identity_provider"/.test(allTf),
+      };
+    },
+  },
+  {
+    id: "stackit_no_sa_key",
+    category: "stackit_backplane",
+    name: "No stackit_service_account_key resource",
+    emoji: "🚫",
+    fn: (mod) => {
+      const allTf = readAllBackplaneTf(mod);
+      if (!allTf) return { pass: true, detail: "no backplane tf files" };
+      return {
+        pass: !/resource\s+"stackit_service_account_key"/.test(allTf),
+        detail: "stackit_service_account_key found — migrate to WIF",
+      };
+    },
+  },
+  {
+    id: "stackit_sa_email_output",
+    category: "stackit_backplane",
+    name: "Outputs service_account_email (not key)",
+    emoji: "📤",
+    fn: (mod) => {
+      const outputsTf = readBackplaneFile(mod, "outputs.tf");
+      if (!outputsTf) return { pass: false, detail: "no outputs.tf" };
+      const hasEmailOutput = /output\s+"service_account_email"/.test(outputsTf);
+      const hasKeyOutput = /output\s+"service_account_key"/.test(outputsTf);
+      return {
+        pass: hasEmailOutput && !hasKeyOutput,
+        detail: !hasEmailOutput
+          ? 'missing output "service_account_email"'
+          : "service_account_key output found — replace with service_account_email",
+      };
+    },
+  },
+  {
+    id: "stackit_provider_oidc",
+    category: "stackit_backplane",
+    name: "Buildingblock provider uses use_oidc = true",
+    emoji: "⚡",
+    fn: (mod) => {
+      const providerTf = join(mod.path, "buildingblock", "provider.tf");
+      if (!existsSync(providerTf)) return { pass: false, detail: "no provider.tf" };
+      const content = readFileSync(providerTf, "utf-8");
+      return {
+        pass: /use_oidc\s*=\s*true/.test(content),
+        detail: "provider.tf does not use use_oidc = true — use WIF instead of service_account_key",
+      };
+    },
+  },
+
   // ─── Testing ────────────────────────────────────────────────────────────
   {
     id: "backplane",
@@ -548,6 +617,7 @@ function discoverModules() {
 const REF_FILES = [
   "AGENTS.md",
   ".agents/references/azure-backplane.md",
+  ".agents/references/stackit-backplane.md",
   ".agents/references/bbd-readme.md",
   ".agents/skills/e2e-test/SKILL.md",
 ];
@@ -825,13 +895,20 @@ function main() {
     lines.push("| Emoji | Criterion | Coverage | Status |");
     lines.push("|-------|-----------|----------|--------|");
     for (const d of catDetectors) {
-      const passing = applicableModules.filter(
-        (r) => r.categoryResults[catId].checks.find((c) => c.id === d.id)?.result.pass
+      const checkApplicable = applicableModules.filter(
+        (r) => r.categoryResults[catId].checks.find((c) => c.id === d.id)?.result.pass !== null
+      );
+      if (checkApplicable.length === 0) {
+        lines.push(`| ${d.emoji} | ${d.name} | n/a | — |`);
+        continue;
+      }
+      const passing = checkApplicable.filter(
+        (r) => r.categoryResults[catId].checks.find((c) => c.id === d.id)?.result.pass === true
       ).length;
-      const pct = Math.round((passing / applicableModules.length) * 100);
+      const pct = Math.round((passing / checkApplicable.length) * 100);
       const bar = pct >= 80 ? "🟢" : pct >= 50 ? "🟡" : "🔴";
       lines.push(
-        `| ${d.emoji} | ${d.name} | **${passing}/${applicableModules.length}** | ${bar} ${pct}% |`
+        `| ${d.emoji} | ${d.name} | **${passing}/${checkApplicable.length}** | ${bar} ${pct}% |`
       );
     }
     lines.push("");


### PR DESCRIPTION
- **fix(e2e): use fixtures.stackit.project_id in storage-bucket test; exclude .terraform from validate-modules scan**
- **test: wire up stackit SA config to provider**
- **feat(stackit/storage-bucket): switch backplane to WIF authentication**
- **fix(stackit/storage-bucket): add service_account_name variable to avoid e2e name collisions**
- **fix(stackit/storage-bucket): shorten e2e SA name to fit STACKIT 20-char limit**
- **fix(stackit/storage-bucket): use api://AzureADTokenExchange aud and azure token path**
- **docs: add debug tooling and fix stackit WIF docs from e2e session learnings**
- **docs: manually review e2e test skill**
