### PR TITLE
fix(meshstack/manual): compute outputs from API, enable SINGLE_SELECT/STATIC inputs

### DIFF
--- a/modules/meshstack/manual/buildingblock/README.md
+++ b/modules/meshstack/manual/buildingblock/README.md
@@ -4,23 +4,23 @@ supportedPlatforms:
   - meshstack
 description: |
   Reference building block demonstrating meshStack's MANUAL implementation type:
-  selected input types mirrored to outputs, with additional inputs that have no corresponding output.
+  the backend derives one output per input, translating types that cannot be outputs.
 ---
 # meshStack Manual Building Block
 
-This building block is a reference implementation demonstrating how meshStack handles the MANUAL implementation type. It exercises output mirroring (outputs copy input values 1:1), the constraint that some input types (e.g. `SINGLE_SELECT`) have no corresponding output type, and the validity of having more inputs than outputs.
+This building block is a reference implementation demonstrating how meshStack handles the MANUAL implementation type. It exercises output mirroring: the backend derives one output per input (assignment type `NONE`), copying input values 1:1 at run time. Input types that cannot be output types are translated — `SINGLE_SELECT` becomes `STRING`, `MULTI_SELECT`/`LIST` become `CODE` — and `STATIC` inputs (supplied by the definition, not the user) are mirrored too.
 
 Use it to:
 - Understand how meshStack handles MANUAL building blocks
-- See which input types can be mirrored to outputs
-- Validate that extra inputs (with no matching output) are allowed
+- See how each input type is mirrored to an output (and how non-output types are translated)
+- Note that outputs are computed: `version_spec.outputs` is omitted from configuration and reconciled from the API
 
 ## Input Types
 
-| Input | Type | Assignment | Mirrored to Output |
-|-------|------|-----------|-------------------|
-| `text` | `STRING` | `USER_INPUT` | ✅ |
-| `flag` | `BOOLEAN` | `USER_INPUT` | ✅ |
-| `num` | `INTEGER` | `USER_INPUT` | ✅ |
-| `single_select` | `SINGLE_SELECT` | `USER_INPUT` | ❌ (no corresponding output type) |
-| `static_note` | `STRING` | `STATIC` | ❌ (extra input without output) |
+| Input | Type | Assignment | Output Type |
+|-------|------|-----------|-------------|
+| `text` | `STRING` | `USER_INPUT` | `STRING` |
+| `flag` | `BOOLEAN` | `USER_INPUT` | `BOOLEAN` |
+| `num` | `INTEGER` | `USER_INPUT` | `INTEGER` |
+| `single_select` | `SINGLE_SELECT` | `USER_INPUT` | `STRING` (translated) |
+| `static_note` | `STRING` | `STATIC` | `STRING` |

--- a/modules/meshstack/manual/e2e/main.tf
+++ b/modules/meshstack/manual/e2e/main.tf
@@ -32,10 +32,10 @@ resource "meshstack_building_block_v2" "this" {
     }
 
     inputs = {
-      text = { value_string = "Hello, Manual World!" }
-      flag = { value_bool = true }
-      num  = { value_int = 42 }
-      # single_select = { value_single_select = "option1" }
+      text          = { value_string = "Hello, Manual World!" }
+      flag          = { value_bool = true }
+      num           = { value_int = 42 }
+      single_select = { value_single_select = "option1" }
       # static_note is STATIC — provided in the BBD, not by the user
     }
   }

--- a/modules/meshstack/manual/e2e/tests/building_block_manual_hub.tftest.hcl
+++ b/modules/meshstack/manual/e2e/tests/building_block_manual_hub.tftest.hcl
@@ -18,4 +18,10 @@ run "building_block_manual_hub" {
     condition     = meshstack_building_block_v2.this.status.outputs["num"].value_int == 42
     error_message = "manual hub building block expected output num to be 42, got ${meshstack_building_block_v2.this.status.outputs["num"].value_int}"
   }
+
+  # SINGLE_SELECT inputs are mirrored to a STRING output by the manual runner.
+  assert {
+    condition     = meshstack_building_block_v2.this.status.outputs["single_select"].value_string == "option1"
+    error_message = "manual hub building block expected output single_select to be 'option1', got ${meshstack_building_block_v2.this.status.outputs["single_select"].value_string}"
+  }
 }

--- a/modules/meshstack/manual/meshstack_integration.tf
+++ b/modules/meshstack/manual/meshstack_integration.tf
@@ -35,7 +35,7 @@ resource "meshstack_building_block_definition" "this" {
 
   spec = {
     display_name = "meshStack Manual Building Block"
-    description  = "Reference building block demonstrating the MANUAL implementation type: outputs mirror selected inputs 1:1, with extra inputs (SINGLE_SELECT and STATIC) that have no corresponding output."
+    description  = "Reference building block demonstrating the MANUAL implementation type: the backend derives one output per input (SINGLE_SELECT is mirrored as STRING), so outputs are computed and must not be configured."
     target_type  = "WORKSPACE_LEVEL"
     readme       = <<-EOT
     This building block demonstrates meshStack's MANUAL implementation type, where platform operators manually confirm execution and output values are copied directly from inputs.
@@ -52,7 +52,7 @@ resource "meshstack_building_block_definition" "this" {
     | Responsibility | Platform Team | Application Team |
     |----------------|:-------------:|:----------------:|
     | Complete the building block run | ✅ | ❌ |
-    | Provide `text`, `flag`, `num`, inputs | ❌ | ✅ |
+    | Provide `text`, `flag`, `num`, `single_select` inputs | ❌ | ✅ |
     | Monitor completion status | ❌ | ✅ |
     EOT
   }
@@ -80,45 +80,26 @@ resource "meshstack_building_block_definition" "this" {
         type            = "INTEGER"
       }
 
-      # TODO: these two currently break the terraform provider because they can't be mapped to an output type
-      # This is a known issue that needs to be fixed in meshStack
-      # > produced an unexpected new value:
-      #  .version_spec.outputs: new element "single_select" has appeared.
-      #  .version_spec.outputs: new element "static_note" has appeared.
-
-      # single_select = {
-      #   assignment_type   = "USER_INPUT"
-      #   display_name      = "Single Select"
-      #   selectable_values = ["option1", "option2"]
-      #   type              = "SINGLE_SELECT"
-      # }
-      # # Static input with no corresponding output — exercises more-inputs-than-outputs
-      # static_note = {
-      #   assignment_type = "STATIC"
-      #   display_name    = "Static Note"
-      #   type            = "STRING"
-      #   argument        = jsonencode("A static note value")
-      # }
-    }
-    # Output keys must match input keys; types must be compatible with manual mirroring.
-    # Only text, flag, and num are output — single_select and static_note are intentionally omitted.
-    outputs = {
-      text = {
-        assignment_type = "NONE"
-        display_name    = "Text"
+      # SINGLE_SELECT cannot be an output type, so the backend mirrors it to a STRING output.
+      single_select = {
+        assignment_type   = "USER_INPUT"
+        display_name      = "Single Select"
+        selectable_values = ["option1", "option2"]
+        type              = "SINGLE_SELECT"
+      }
+      # STATIC input supplied by the building block definition (not the user); also mirrored to a STRING output.
+      static_note = {
+        assignment_type = "STATIC"
+        display_name    = "Static Note"
         type            = "STRING"
-      }
-      flag = {
-        assignment_type = "NONE"
-        display_name    = "Flag"
-        type            = "BOOLEAN"
-      }
-      num = {
-        assignment_type = "NONE"
-        display_name    = "Num"
-        type            = "INTEGER"
+        argument        = jsonencode("A static note value")
       }
     }
+
+    # Outputs are omitted for manual building blocks: the backend derives one output per input
+    # (assignment type NONE, with SINGLE_SELECT/MULTI_SELECT/LIST translated to output-compatible
+    # types), so version_spec.outputs is computed and must not be set here.
+    # Requires the meshstack provider >= 0.21.1 (see meshcloud/terraform-provider-meshstack#176).
   }
 }
 


### PR DESCRIPTION
## What

Adapts the **meshStack Manual** reference building block to the manual-outputs
change in [terraform-provider-meshstack#176](https://github.com/meshcloud/terraform-provider-meshstack/pull/176), and resolves the long-standing TODO that kept the `SINGLE_SELECT` / `STATIC` inputs commented out.

- **Remove the `version_spec.outputs` block** — for manual building blocks the backend derives one output per input (`ManualBuildingBlockCreationModule`: assignment type `NONE`, with `SINGLE_SELECT`/`MULTI_SELECT`/`LIST` translated via `ManualIOTypeTranslation`). With #176 the provider treats `version_spec.outputs` as **computed** and reconciles it from the API, so configuring it caused *"Provider produced inconsistent result after apply"*.
- **Enable the `single_select` (`SINGLE_SELECT`) and `static_note` (`STATIC`) inputs** that the TODO had disabled. The backend mirrors them (`SINGLE_SELECT` → `STRING`), so they no longer break the apply.
- **e2e**: supply `single_select` as a user input and assert its mirrored `STRING` output.
- **Docs**: update the building block README and the BBD description to reflect that every input is mirrored to an output (with type translation) and that outputs are computed.

## Why the TODO is now resolved

The TODO referenced *"new element single_select/static_note has appeared"* in `version_spec.outputs`. Root cause: the backend always derived outputs from **all** inputs, but the provider expected the configured outputs to match exactly. Confirmed in `meshfed-release`:
- `ManualBuildingBlockCreationModule.performImplementationTypeSpecificLogic` → one output per input.
- `ManualIOTypeTranslation.translateIOTypeToOutput` → `SINGLE_SELECT`→`STRING`, `MULTI_SELECT`/`LIST`→`CODE`.

#176 adapts the provider to this (computed outputs), so the inputs can be enabled.

## Dependency

Requires the **meshstack provider ≥ 0.21.1** (carries #176). The module keeps the conventional `~> 0.21.0` pin (minor-pinning per `AGENTS.md`), which resolves to the latest patch at apply time — **merge after provider v0.21.1 is released.**

## Validation

- `terraform fmt` ✅, `ci/validate_modules.sh` ✅, `terraform validate` (module root + e2e) ✅
- pre-commit hooks (fmt / docs / validate modules / whitespace) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)