### PR TITLE
refactor: switch provider version constraints from ~> to >= across all modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,16 +65,16 @@ A secondary purpose of these files is to serve as a ready-to-use Terraform modul
 ### Required providers
 
 Every `meshstack_integration.tf` must declare the `meshcloud/meshstack` provider in a
-`required_providers` block. Pin the meshstack provider to the current minor version using
-`~> X.Y.0` (e.g. `~> 0.20.0`). This is an exception to the general `~> X.Y.Z` patch-pinning
-rule because the meshstack provider is pre-1.0 and minor versions may contain breaking changes.
+`required_providers` block. Use a minimum version constraint with `>=` (e.g. `>= 0.20.0`).
+Root configurations (ICF/LCF) that source hub modules are responsible for strict version
+pinning via their `.terraform.lock.hcl` files.
 
 ```hcl
 terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.20.0"
+      version = ">= 0.20.0"
     }
   }
 }
@@ -168,7 +168,7 @@ resource "meshstack_building_block_definition" "this" {
 - **Cloud-provider-specific variables** in `meshstack_integration.tf` must be **flat** (not grouped into a single object) and prefixed with the cloud provider name: `azure_tenant_id`, `aws_region`, `gcp_project_id`, `stackit_project_id`
 - **Cross-cutting concerns** like workload identity federation settings may be grouped into an `object({})` typed variable (e.g. `variable "workload_identity"`) when the fields are logically inseparable
 - Only `variable "meshstack"` and `variable "hub"` use shared `object({})` conventions across all integrations
-- Pin provider versions with `~> X.Y.Z` (allow patch updates, not minor/major). **Exception:** the `meshcloud/meshstack` provider is pre-1.0, so pin to the minor version with `~> 0.Y.0` (e.g. `~> 0.20.0`)
+- Use minimum version constraints (`>= X.Y.Z`) for all providers in `versions.tf` and `meshstack_integration.tf`. Strict pinning is the responsibility of root configurations (ICF/LCF) via `.terraform.lock.hcl`.
 - Terraform baseline: `>= 1.12.0` to cover OpenTofu v1.12.0 with `const` variable support (requires OpenTofu ≥ 1.12 or Terraform ≥ 1.15)
 
 ---
@@ -317,7 +317,7 @@ See [.agents/skills/write-e2e-test/SKILL.md](.agents/skills/write-e2e-test/SKILL
 
 - [ ] `backplane/` (optional) and `buildingblock/` with all required files
 - [ ] `meshstack_integration.tf` present at the module root
-- [ ] Provider versions pinned with `~>`
+- [ ] Provider versions use minimum constraint (`>=`) in `versions.tf` and `meshstack_integration.tf`
 - [ ] Variables in `snake_case` with cloud-provider prefix in `meshstack_integration.tf` (e.g. `azure_tenant_id`)
 - [ ] `buildingblock/README.md` with YAML front-matter
 - [ ] BBD `readme` field uses `chomp(<<-EOT)` inline (no `file()`), starts with plain-text description (no `#` heading), and includes usage motivation, 1–2 examples, and a shared responsibility table with ✅ / ❌ — see [.agents/skills/bbd-readme.md](.agents/skills/bbd-readme.md)

--- a/modules/aks/github-connector/buildingblock/README.md
+++ b/modules/aks/github-connector/buildingblock/README.md
@@ -39,9 +39,9 @@ terraform {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.5.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.35.1 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | 0.11.1 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.5.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.35.1 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |
 
 ## Modules
 
@@ -51,15 +51,15 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_actions_environment_secret.container_registry](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/actions_environment_secret) | resource |
-| [github_actions_environment_secret.kubeconfig](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/actions_environment_secret) | resource |
-| [github_actions_environment_variable.additional](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/actions_environment_variable) | resource |
-| [github_repository_environment.env](https://registry.terraform.io/providers/integrations/github/6.5.0/docs/resources/repository_environment) | resource |
-| [kubernetes_cluster_role_binding.github_actions_clusterissuer_access](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/cluster_role_binding) | resource |
-| [kubernetes_role_binding.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/role_binding) | resource |
-| [kubernetes_secret.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
-| [kubernetes_secret.image_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
-| [kubernetes_service_account.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/service_account) | resource |
+| [github_actions_environment_secret.container_registry](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
+| [github_actions_environment_secret.kubeconfig](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
+| [github_actions_environment_variable.additional](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_variable) | resource |
+| [github_repository_environment.env](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
+| [kubernetes_cluster_role_binding.github_actions_clusterissuer_access](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_role_binding.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+| [kubernetes_secret.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.image_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_service_account.github_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [terraform_data.workflow_dispatch](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 ## Inputs

--- a/modules/aks/github-connector/buildingblock/versions.tf
+++ b/modules/aks/github-connector/buildingblock/versions.tf
@@ -2,17 +2,17 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.5.0"
+      version = ">= 6.5.0"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.35.1"
+      version = ">= 2.35.1"
     }
 
     time = {
       source  = "hashicorp/time"
-      version = "0.11.1"
+      version = ">= 0.11.1"
     }
   }
 }

--- a/modules/aks/github-connector/meshstack_integration.tf
+++ b/modules/aks/github-connector/meshstack_integration.tf
@@ -229,7 +229,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/aks/meshstack_integration.tf
+++ b/modules/aks/meshstack_integration.tf
@@ -29,7 +29,7 @@ variable "meshstack" {
 
 module "aks_meshplatform" {
   source  = "meshcloud/meshplatform/aks"
-  version = "~> 0.2.0"
+  version = ">= 0.2.0"
 
   namespace = "meshcloud"
   scope     = var.aks_subscription_id
@@ -179,11 +179,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.8"
+      version = ">= 3.8"
     }
   }
 }

--- a/modules/aks/postgresql/buildingblock/README.md
+++ b/modules/aks/postgresql/buildingblock/README.md
@@ -48,9 +48,9 @@ terraform {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.4.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.35.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.4.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.35.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.3 |
 
 ## Modules
 
@@ -60,10 +60,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_postgresql_flexible_server.db_instance](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/postgresql_flexible_server) | resource |
-| [kubernetes_secret.credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
-| [random_password.administrator_password](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/password) | resource |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/data-sources/subscription) | data source |
+| [azurerm_postgresql_flexible_server.db_instance](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
+| [kubernetes_secret.credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [random_password.administrator_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/aks/postgresql/buildingblock/versions.tf
+++ b/modules/aks/postgresql/buildingblock/versions.tf
@@ -4,17 +4,17 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.4.0"
+      version = ">= 4.4.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "3.6.3"
+      version = ">= 3.6.3"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.35.1"
+      version = ">= 2.35.1"
     }
   }
 }

--- a/modules/aks/starterkit/buildingblock/README.md
+++ b/modules/aks/starterkit/buildingblock/README.md
@@ -15,7 +15,7 @@ This documentation is intended as a reference documentation for cloud foundation
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | ~> 0.21.0 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.21.0 |
 
 ## Modules
 

--- a/modules/aks/starterkit/buildingblock/versions.tf
+++ b/modules/aks/starterkit/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/aks/starterkit/meshstack_integration.tf
+++ b/modules/aks/starterkit/meshstack_integration.tf
@@ -334,7 +334,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/aws/agentic-coding-sandbox/buildingblock/README.md
+++ b/modules/aws/agentic-coding-sandbox/buildingblock/README.md
@@ -77,7 +77,7 @@ End users provide:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | 0.7.1 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.7.1 |
 
 ## Modules
 
@@ -87,10 +87,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [meshstack_buildingblock.budget_alert](https://registry.terraform.io/providers/meshcloud/meshstack/0.7.1/docs/resources/buildingblock) | resource |
-| [meshstack_buildingblock.enable_eu_south_2_region](https://registry.terraform.io/providers/meshcloud/meshstack/0.7.1/docs/resources/buildingblock) | resource |
-| [meshstack_project.sandbox](https://registry.terraform.io/providers/meshcloud/meshstack/0.7.1/docs/resources/project) | resource |
-| [meshstack_tenant.sandbox](https://registry.terraform.io/providers/meshcloud/meshstack/0.7.1/docs/resources/tenant) | resource |
+| [meshstack_buildingblock.budget_alert](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/buildingblock) | resource |
+| [meshstack_buildingblock.enable_eu_south_2_region](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/buildingblock) | resource |
+| [meshstack_project.sandbox](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
+| [meshstack_tenant.sandbox](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs

--- a/modules/aws/agentic-coding-sandbox/buildingblock/versions.tf
+++ b/modules/aws/agentic-coding-sandbox/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "0.7.1"
+      version = ">= 0.7.1"
     }
   }
 }

--- a/modules/aws/alternate-contacts/backplane/README.md
+++ b/modules/aws/alternate-contacts/backplane/README.md
@@ -34,7 +34,7 @@ module "alternate_contacts_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/aws/alternate-contacts/backplane/versions.tf
+++ b/modules/aws/alternate-contacts/backplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
 
       configuration_aliases = [
         # This provider needs to point at the account owning your AWS Organization

--- a/modules/aws/alternate-contacts/buildingblock/README.md
+++ b/modules/aws/alternate-contacts/buildingblock/README.md
@@ -51,7 +51,7 @@ Please reference the [backplane implementation](../backplane/) for the required 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/aws/alternate-contacts/buildingblock/versions.tf
+++ b/modules/aws/alternate-contacts/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/aws/budget-alert/backplane/README.md
+++ b/modules/aws/budget-alert/backplane/README.md
@@ -8,7 +8,7 @@ This Terraform module provides the necessary IAM roles and permissions to enable
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/aws/budget-alert/backplane/versions.tf
+++ b/modules/aws/budget-alert/backplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
 
       configuration_aliases = [
         # This provider needs to point at the account owning your AWS Organization

--- a/modules/aws/budget-alert/buildingblock/README.md
+++ b/modules/aws/budget-alert/buildingblock/README.md
@@ -18,8 +18,8 @@ Please reference the [backplane implementation](../backplane/) for the required 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.11.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |
 
 ## Modules
 

--- a/modules/aws/budget-alert/buildingblock/versions.tf
+++ b/modules/aws/budget-alert/buildingblock/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.11.1"
+      version = ">= 0.11.1"
     }
   }
 }

--- a/modules/aws/opt-in-region/buildingblock/README.md
+++ b/modules/aws/opt-in-region/buildingblock/README.md
@@ -12,7 +12,7 @@ description: |
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.77.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.77.0 |
 
 ## Modules
 
@@ -22,7 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_account_region.region](https://registry.terraform.io/providers/hashicorp/aws/5.77.0/docs/resources/account_region) | resource |
+| [aws_account_region.region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/account_region) | resource |
 
 ## Inputs
 

--- a/modules/aws/opt-in-region/buildingblock/versions.tf
+++ b/modules/aws/opt-in-region/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.77.0"
+      version = ">= 5.77.0"
     }
   }
 }

--- a/modules/aws/route53-dns-alias-record/backplane/README.md
+++ b/modules/aws/route53-dns-alias-record/backplane/README.md
@@ -39,8 +39,8 @@ output "aws_route53_dns_alias_record_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.32 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.32 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Modules
 

--- a/modules/aws/route53-dns-alias-record/backplane/versions.tf
+++ b/modules/aws/route53-dns-alias-record/backplane/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.32"
+      version = ">= 6.32"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/modules/aws/route53-dns-alias-record/buildingblock/README.md
+++ b/modules/aws/route53-dns-alias-record/buildingblock/README.md
@@ -11,7 +11,7 @@ description: Provides AWS Route53 DNS alias records
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.32 |
 
 ## Modules
 

--- a/modules/aws/route53-dns-alias-record/buildingblock/versions.tf
+++ b/modules/aws/route53-dns-alias-record/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.32"
+      version = ">= 6.32"
     }
   }
 }

--- a/modules/aws/route53-dns-alias-record/meshstack_integration.tf
+++ b/modules/aws/route53-dns-alias-record/meshstack_integration.tf
@@ -232,11 +232,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.32"
+      version = ">= 6.32"
     }
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/aws/route53-dns-record/backplane/README.md
+++ b/modules/aws/route53-dns-record/backplane/README.md
@@ -39,8 +39,8 @@ output "aws_route53_dns_record_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.32 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.32 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Modules
 

--- a/modules/aws/route53-dns-record/backplane/versions.tf
+++ b/modules/aws/route53-dns-record/backplane/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.32"
+      version = ">= 6.32"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/modules/aws/route53-dns-record/buildingblock/README.md
+++ b/modules/aws/route53-dns-record/buildingblock/README.md
@@ -11,7 +11,7 @@ description: Provides AWS Route53 DNS records for mapping domain names to IP add
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.32 |
 
 ## Modules
 

--- a/modules/aws/route53-dns-record/buildingblock/versions.tf
+++ b/modules/aws/route53-dns-record/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.32"
+      version = ">= 6.32"
     }
   }
 }

--- a/modules/aws/route53-dns-record/meshstack_integration.tf
+++ b/modules/aws/route53-dns-record/meshstack_integration.tf
@@ -226,11 +226,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.32"
+      version = ">= 6.32"
     }
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/aws/s3_bucket/backplane/README.md
+++ b/modules/aws/s3_bucket/backplane/README.md
@@ -40,7 +40,7 @@ output "aws_s3_bucket_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.12.0 |
 
 ## Modules
 

--- a/modules/aws/s3_bucket/backplane/versions.tf
+++ b/modules/aws/s3_bucket/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.12.0"
+      version = ">= 6.12.0"
     }
   }
 }

--- a/modules/aws/s3_bucket/buildingblock/README.md
+++ b/modules/aws/s3_bucket/buildingblock/README.md
@@ -36,7 +36,7 @@ provider "aws" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.77.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.77.0 |
 
 ## Modules
 

--- a/modules/aws/s3_bucket/buildingblock/versions.tf
+++ b/modules/aws/s3_bucket/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.77.0"
+      version = ">= 5.77.0"
     }
   }
 }

--- a/modules/aws/s3_bucket/meshstack_integration.tf
+++ b/modules/aws/s3_bucket/meshstack_integration.tf
@@ -184,11 +184,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.12.0"
+      version = ">= 6.12.0"
     }
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/azure/aks/backplane/README.md
+++ b/modules/azure/aks/backplane/README.md
@@ -13,7 +13,7 @@ across all subscriptions underneath a management group (typically the top-level 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.36.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36.0 |
 
 ## Modules
 

--- a/modules/azure/aks/backplane/versions.tf
+++ b/modules/azure/aks/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.36.0"
+      version = ">= 4.36.0"
     }
   }
 }

--- a/modules/azure/aks/buildingblock/README.md
+++ b/modules/azure/aks/buildingblock/README.md
@@ -196,8 +196,8 @@ module "aks" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.36.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.11.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |
 
 ## Modules
 

--- a/modules/azure/aks/buildingblock/versions.tf
+++ b/modules/azure/aks/buildingblock/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "~> 4.36.0"
+      version               = ">= 4.36.0"
       configuration_aliases = [azurerm, azurerm.hub]
     }
 
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.11.1"
+      version = ">= 0.11.1"
     }
   }
 }

--- a/modules/azure/azure-bastion/buildingblock/README.md
+++ b/modules/azure/azure-bastion/buildingblock/README.md
@@ -133,8 +133,8 @@ This building block implements all required network security group rules for Azu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.11.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |
 
 ## Modules
 

--- a/modules/azure/azure-bastion/buildingblock/versions.tf
+++ b/modules/azure/azure-bastion/buildingblock/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.116.0"
+      version = ">= 3.116.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.11.1"
+      version = ">= 0.11.1"
     }
   }
 }

--- a/modules/azure/azure-virtual-machine-starterkit/buildingblock/README.md
+++ b/modules/azure/azure-virtual-machine-starterkit/buildingblock/README.md
@@ -39,7 +39,7 @@ The Azure VM Starterkit building block automates the creation of a complete Azur
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | 0.9.0 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.9.0 |
 
 ## Modules
 
@@ -49,10 +49,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [meshstack_building_block_v2.azure_vm](https://registry.terraform.io/providers/meshcloud/meshstack/0.9.0/docs/resources/building_block_v2) | resource |
-| [meshstack_project.vm_project](https://registry.terraform.io/providers/meshcloud/meshstack/0.9.0/docs/resources/project) | resource |
-| [meshstack_project_user_binding.creator_admin](https://registry.terraform.io/providers/meshcloud/meshstack/0.9.0/docs/resources/project_user_binding) | resource |
-| [meshstack_tenant_v4.vm_tenant](https://registry.terraform.io/providers/meshcloud/meshstack/0.9.0/docs/resources/tenant_v4) | resource |
+| [meshstack_building_block_v2.azure_vm](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block_v2) | resource |
+| [meshstack_project.vm_project](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
+| [meshstack_project_user_binding.creator_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
+| [meshstack_tenant_v4.vm_tenant](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant_v4) | resource |
 
 ## Inputs
 

--- a/modules/azure/azure-virtual-machine-starterkit/buildingblock/versions.tf
+++ b/modules/azure/azure-virtual-machine-starterkit/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "0.9.0"
+      version = ">= 0.9.0"
     }
   }
 }

--- a/modules/azure/azure-virtual-machine/backplane/README.md
+++ b/modules/azure/azure-virtual-machine/backplane/README.md
@@ -66,8 +66,8 @@ module "vm_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~>3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4.50.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.50.0 |
 
 ## Modules
 

--- a/modules/azure/azure-virtual-machine/backplane/versions.tf
+++ b/modules/azure/azure-virtual-machine/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.50.0"
+      version = ">=4.50.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~>3.6.0"
+      version = ">=3.6.0"
     }
   }
 }

--- a/modules/azure/azure-virtual-machine/buildingblock/README.md
+++ b/modules/azure/azure-virtual-machine/buildingblock/README.md
@@ -140,9 +140,9 @@ module "spot_vm" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~>3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4.50.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.7.2 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.50.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >=3.7.2 |
 
 ## Modules
 

--- a/modules/azure/azure-virtual-machine/buildingblock/versions.tf
+++ b/modules/azure/azure-virtual-machine/buildingblock/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.50.0"
+      version = ">=4.50.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~>3.6.0"
+      version = ">=3.6.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.7.2"
+      version = ">=3.7.2"
     }
   }
 }

--- a/modules/azure/budget-alert/backplane/README.md
+++ b/modules/azure/budget-alert/backplane/README.md
@@ -12,7 +12,7 @@ across all subscriptions underneath a management group (typically the top-level 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.64.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.64.0 |
 
 ## Modules
 

--- a/modules/azure/budget-alert/backplane/versions.tf
+++ b/modules/azure/budget-alert/backplane/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64.0"
+      version = ">= 4.64.0"
     }
   }
 }

--- a/modules/azure/budget-alert/buildingblock/README.md
+++ b/modules/azure/budget-alert/buildingblock/README.md
@@ -20,8 +20,8 @@ Please reference the [backplane implementation](../backplane/) for the required 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.64.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.11.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.64.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.0 |
 
 ## Modules
 

--- a/modules/azure/budget-alert/buildingblock/versions.tf
+++ b/modules/azure/budget-alert/buildingblock/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64.0"
+      version = ">= 4.64.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/modules/azure/budget-alert/meshstack_integration.tf
+++ b/modules/azure/budget-alert/meshstack_integration.tf
@@ -227,11 +227,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64.0"
+      version = ">= 4.64.0"
     }
   }
 }

--- a/modules/azure/container-registry/backplane/README.md
+++ b/modules/azure/container-registry/backplane/README.md
@@ -127,8 +127,8 @@ module "acr_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.36.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36.0 |
 
 ## Modules
 

--- a/modules/azure/container-registry/backplane/versions.tf
+++ b/modules/azure/container-registry/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.36.0"
+      version = ">= 4.36.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azure/container-registry/buildingblock/README.md
+++ b/modules/azure/container-registry/buildingblock/README.md
@@ -148,8 +148,8 @@ When using an existing VNet:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.36.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.0 |
 
 ## Modules
 

--- a/modules/azure/container-registry/buildingblock/versions.tf
+++ b/modules/azure/container-registry/buildingblock/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "~> 4.36.0"
+      version               = ">= 4.36.0"
       configuration_aliases = [azurerm, azurerm.hub]
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azure/github-actions-terraform-setup/buildingblock/README.md
+++ b/modules/azure/github-actions-terraform-setup/buildingblock/README.md
@@ -23,11 +23,11 @@ For more information, refer to the backplane documentation of the [Azure GitHub 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 3.0.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.4.0 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.3.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | 0.11.1 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0.2 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.4.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.3 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |
 
 ## Modules
 
@@ -37,29 +37,29 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_federated_identity_credential.ghactions](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/federated_identity_credential) | resource |
-| [azurerm_resource_group.app](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.cicd](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.ghaction_tfstate](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.ghactions_app](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.ghactions_register](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.project_admins_blobs](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.ghactions](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/role_definition) | resource |
-| [azurerm_role_definition.ghactions_register](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/role_definition) | resource |
-| [azurerm_storage_account.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_container.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/storage_container) | resource |
-| [azurerm_user_assigned_identity.ghactions](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/resources/user_assigned_identity) | resource |
-| [github_actions_secret.arm_client_id](https://registry.terraform.io/providers/integrations/github/6.3.0/docs/resources/actions_secret) | resource |
-| [github_repository_environment.sandbox](https://registry.terraform.io/providers/integrations/github/6.3.0/docs/resources/repository_environment) | resource |
-| [github_repository_environment_deployment_policy.sandbox_all](https://registry.terraform.io/providers/integrations/github/6.3.0/docs/resources/repository_environment_deployment_policy) | resource |
-| [github_repository_file.backend_tf](https://registry.terraform.io/providers/integrations/github/6.3.0/docs/resources/repository_file) | resource |
-| [github_repository_file.provider_tf](https://registry.terraform.io/providers/integrations/github/6.3.0/docs/resources/repository_file) | resource |
-| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/0.11.1/docs/resources/sleep) | resource |
-| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/3.0.2/docs/data-sources/client_config) | data source |
-| [azuread_group.project_admins](https://registry.terraform.io/providers/hashicorp/azuread/3.0.2/docs/data-sources/group) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.4.0/docs/data-sources/subscription) | data source |
-| [github_repository.repository](https://registry.terraform.io/providers/integrations/github/6.3.0/docs/data-sources/repository) | data source |
+| [azurerm_federated_identity_credential.ghactions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_resource_group.app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.cicd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.ghaction_tfstate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.ghactions_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.ghactions_register](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.project_admins_blobs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.ghactions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.ghactions_register](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_storage_account.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_user_assigned_identity.ghactions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [github_actions_secret.arm_client_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [github_repository_environment.sandbox](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
+| [github_repository_environment_deployment_policy.sandbox_all](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
+| [github_repository_file.backend_tf](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.provider_tf](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_group.project_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [github_repository.repository](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
 
 ## Inputs
 

--- a/modules/azure/github-actions-terraform-setup/buildingblock/versions.tf
+++ b/modules/azure/github-actions-terraform-setup/buildingblock/versions.tf
@@ -4,27 +4,27 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.4.0"
+      version = ">= 4.4.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "3.0.2"
+      version = ">= 3.0.2"
     }
 
     github = {
       source  = "integrations/github"
-      version = "6.3.0"
+      version = ">= 6.3.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "3.6.3"
+      version = ">= 3.6.3"
     }
 
     time = {
       source  = "hashicorp/time"
-      version = "0.11.1"
+      version = ">= 0.11.1"
     }
   }
 }

--- a/modules/azure/key-vault/backplane/README.md
+++ b/modules/azure/key-vault/backplane/README.md
@@ -13,8 +13,8 @@ across all subscriptions underneath a management group (typically the top-level 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.36.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36.0 |
 
 ## Modules
 

--- a/modules/azure/key-vault/backplane/versions.tf
+++ b/modules/azure/key-vault/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.36.0"
+      version = ">= 4.36.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azure/key-vault/buildingblock/README.md
+++ b/modules/azure/key-vault/buildingblock/README.md
@@ -88,9 +88,9 @@ provider "azurerm" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 3.1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.18.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.1.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.18.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.3 |
 
 ## Modules
 
@@ -100,22 +100,22 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/key_vault) | resource |
-| [azurerm_private_dns_zone.key_vault_dns](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/private_dns_zone) | resource |
-| [azurerm_private_dns_zone_virtual_network_link.key_vault_dns_link](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurerm_private_endpoint.key_vault_pe](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/private_endpoint) | resource |
-| [azurerm_resource_group.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/resource_group) | resource |
-| [azurerm_subnet.pe_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/subnet) | resource |
-| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.hub_to_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/virtual_network_peering) | resource |
-| [azurerm_virtual_network_peering.key_vault_to_hub](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/virtual_network_peering) | resource |
-| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.hub_rg](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/resource_group) | data source |
-| [azurerm_subnet.existing_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/subnet) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/subscription) | data source |
-| [azurerm_virtual_network.existing_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/virtual_network) | data source |
-| [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/virtual_network) | data source |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
+| [azurerm_private_dns_zone.key_vault_dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.key_vault_dns_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_endpoint.key_vault_pe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_resource_group.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.pe_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.hub_to_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
+| [azurerm_virtual_network_peering.key_vault_to_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
+| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.hub_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_subnet.existing_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_virtual_network.existing_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 

--- a/modules/azure/key-vault/buildingblock/versions.tf
+++ b/modules/azure/key-vault/buildingblock/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.18.0"
+      version = ">= 4.18.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "3.1.0"
+      version = ">= 3.1.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.6.3"
+      version = ">= 3.6.3"
     }
   }
 }

--- a/modules/azure/meshstack_integration.tf
+++ b/modules/azure/meshstack_integration.tf
@@ -62,7 +62,7 @@ data "azurerm_management_group" "parent" {
 # Creates required resource in Azure
 module "azure_meshplatform" {
   source  = "meshcloud/meshplatform/azure"
-  version = "~> 0.14.0"
+  version = ">= 0.14.0"
 
   replicator_enabled                = true
   replicator_service_principal_name = "meshstack-replicator"
@@ -245,15 +245,15 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64"
+      version = ">= 4.64"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.8"
+      version = ">= 3.8"
     }
   }
 }

--- a/modules/azure/postgresql/buildingblock/README.md
+++ b/modules/azure/postgresql/buildingblock/README.md
@@ -19,8 +19,8 @@ This Terraform project deploys a cost-effective Azure PostgreSQL database with m
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.22.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.7.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.22.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.7.1 |
 
 ## Modules
 
@@ -30,9 +30,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_postgresql_server.example](https://registry.terraform.io/providers/hashicorp/azurerm/4.22.0/docs/resources/postgresql_server) | resource |
-| [azurerm_resource_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/4.22.0/docs/resources/resource_group) | resource |
-| [random_password.psql_admin_password](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/password) | resource |
+| [azurerm_postgresql_server.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_server) | resource |
+| [azurerm_resource_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [random_password.psql_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs
 

--- a/modules/azure/postgresql/buildingblock/versions.tf
+++ b/modules/azure/postgresql/buildingblock/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.22.0"
+      version = ">= 4.22.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.7.1"
+      version = ">= 3.7.1"
     }
   }
 }

--- a/modules/azure/resource-group/backplane/versions.tf
+++ b/modules/azure/resource-group/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64.0"
+      version = ">= 4.64.0"
     }
   }
 }

--- a/modules/azure/resource-group/buildingblock/versions.tf
+++ b/modules/azure/resource-group/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64.0"
+      version = ">= 4.64.0"
     }
   }
 }

--- a/modules/azure/resource-group/meshstack_integration.tf
+++ b/modules/azure/resource-group/meshstack_integration.tf
@@ -223,11 +223,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64.0"
+      version = ">= 4.64.0"
     }
   }
 }

--- a/modules/azure/service-principal/backplane/README.md
+++ b/modules/azure/service-principal/backplane/README.md
@@ -39,8 +39,8 @@ The automation principal requires the following Microsoft Graph API application 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.36.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36.0 |
 
 ## Modules
 

--- a/modules/azure/service-principal/backplane/versions.tf
+++ b/modules/azure/service-principal/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.36.0"
+      version = ">= 4.36.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azure/service-principal/buildingblock/README.md
+++ b/modules/azure/service-principal/buildingblock/README.md
@@ -210,9 +210,9 @@ module "azuredevops_service_connection" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.11.1 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |
 
 ## Modules
 

--- a/modules/azure/service-principal/buildingblock/versions.tf
+++ b/modules/azure/service-principal/buildingblock/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.11.1"
+      version = ">= 0.11.1"
     }
   }
 }

--- a/modules/azure/service-principal/meshstack_integration.tf
+++ b/modules/azure/service-principal/meshstack_integration.tf
@@ -255,15 +255,15 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64"
+      version = ">= 4.64"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.8"
+      version = ">= 3.8"
     }
   }
 }

--- a/modules/azure/spoke-network/buildingblock/README.md
+++ b/modules/azure/spoke-network/buildingblock/README.md
@@ -15,8 +15,8 @@ This enables use cases like on-premise connectivity and managed internet egress 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.11.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | 0.12.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.11.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.12.1 |
 
 ## Modules
 
@@ -26,16 +26,16 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.spoke_rg](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.spoke_rg](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/role_assignment) | resource |
-| [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.hub_spoke_peer](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/virtual_network_peering) | resource |
-| [azurerm_virtual_network_peering.spoke_hub_peer](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/virtual_network_peering) | resource |
-| [time_sleep.wait_before_peering](https://registry.terraform.io/providers/hashicorp/time/0.12.1/docs/resources/sleep) | resource |
-| [time_sleep.wait_for_spoke_rg_role](https://registry.terraform.io/providers/hashicorp/time/0.12.1/docs/resources/sleep) | resource |
-| [azurerm_client_config.spoke](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.hub_rg](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/data-sources/resource_group) | data source |
-| [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/data-sources/virtual_network) | data source |
+| [azurerm_resource_group.spoke_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.spoke_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.hub_spoke_peer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
+| [azurerm_virtual_network_peering.spoke_hub_peer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
+| [time_sleep.wait_before_peering](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [time_sleep.wait_for_spoke_rg_role](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [azurerm_client_config.spoke](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.hub_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_virtual_network.hub_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 

--- a/modules/azure/spoke-network/buildingblock/versions.tf
+++ b/modules/azure/spoke-network/buildingblock/versions.tf
@@ -5,13 +5,13 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "4.11.0"
+      version               = ">= 4.11.0"
       configuration_aliases = [azurerm.spoke, azurerm.hub]
     }
 
     time = {
       source  = "hashicorp/time"
-      version = "0.12.1"
+      version = ">= 0.12.1"
     }
   }
 }

--- a/modules/azure/storage-account/backplane/README.md
+++ b/modules/azure/storage-account/backplane/README.md
@@ -108,7 +108,7 @@ module "storage_account_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.64 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.64 |
 
 ## Modules
 

--- a/modules/azure/storage-account/backplane/versions.tf
+++ b/modules/azure/storage-account/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64"
+      version = ">= 4.64"
     }
   }
 }

--- a/modules/azure/storage-account/buildingblock/README.md
+++ b/modules/azure/storage-account/buildingblock/README.md
@@ -37,9 +37,9 @@ provider "azurerm" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.8 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.64 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.8 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.8 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.64 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.8 |
 
 ## Modules
 

--- a/modules/azure/storage-account/buildingblock/versions.tf
+++ b/modules/azure/storage-account/buildingblock/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64"
+      version = ">= 4.64"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.8"
+      version = ">= 3.8"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.8"
+      version = ">= 3.8"
     }
   }
 }

--- a/modules/azure/storage-account/meshstack_integration.tf
+++ b/modules/azure/storage-account/meshstack_integration.tf
@@ -214,11 +214,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.64"
+      version = ">= 4.64"
     }
   }
 }

--- a/modules/azure/vmss/buildingblock/README.md
+++ b/modules/azure/vmss/buildingblock/README.md
@@ -307,8 +307,8 @@ See repository root for license information.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.18.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.18.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.3 |
 
 ## Modules
 
@@ -318,25 +318,25 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_lb.vmss_lb](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/lb) | resource |
-| [azurerm_lb_backend_address_pool.vmss_backend_pool](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/lb_backend_address_pool) | resource |
-| [azurerm_lb_probe.vmss_health_probe](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/lb_probe) | resource |
-| [azurerm_lb_rule.vmss_lb_rule](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/lb_rule) | resource |
-| [azurerm_linux_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/linux_virtual_machine_scale_set) | resource |
-| [azurerm_monitor_autoscale_setting.vmss_autoscale](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/monitor_autoscale_setting) | resource |
-| [azurerm_network_security_group.vmss_nsg](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/network_security_group) | resource |
-| [azurerm_network_security_rule.allow_backend_port](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/network_security_rule) | resource |
-| [azurerm_network_security_rule.allow_rdp](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/network_security_rule) | resource |
-| [azurerm_network_security_rule.allow_ssh](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/network_security_rule) | resource |
-| [azurerm_public_ip.lb_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/public_ip) | resource |
-| [azurerm_resource_group.vmss_rg](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/resource_group) | resource |
-| [azurerm_subnet_network_security_group_association.vmss_nsg_association](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_windows_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/windows_virtual_machine_scale_set) | resource |
-| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/client_config) | data source |
-| [azurerm_subnet.vmss_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/subnet) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/subscription) | data source |
-| [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/data-sources/virtual_network) | data source |
+| [azurerm_lb.vmss_lb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb) | resource |
+| [azurerm_lb_backend_address_pool.vmss_backend_pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_backend_address_pool) | resource |
+| [azurerm_lb_probe.vmss_health_probe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_probe) | resource |
+| [azurerm_lb_rule.vmss_lb_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_rule) | resource |
+| [azurerm_linux_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_monitor_autoscale_setting.vmss_autoscale](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) | resource |
+| [azurerm_network_security_group.vmss_nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_network_security_rule.allow_backend_port](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.allow_rdp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.allow_ssh](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.lb_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.vmss_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet_network_security_group_association.vmss_nsg_association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_windows_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine_scale_set) | resource |
+| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_subnet.vmss_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_virtual_network.spoke_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 

--- a/modules/azure/vmss/buildingblock/versions.tf
+++ b/modules/azure/vmss/buildingblock/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.18.0"
+      version = ">= 4.18.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.6.3"
+      version = ">= 3.6.3"
     }
   }
 }

--- a/modules/azuredevops/agent-pool/backplane/README.md
+++ b/modules/azuredevops/agent-pool/backplane/README.md
@@ -105,8 +105,8 @@ The custom role grants the service principal:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/agent-pool/backplane/versions.tf
+++ b/modules/azuredevops/agent-pool/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
   }
 }

--- a/modules/azuredevops/agent-pool/buildingblock/README.md
+++ b/modules/azuredevops/agent-pool/buildingblock/README.md
@@ -159,8 +159,8 @@ Agent pool administration is managed at the **organization level** in Azure DevO
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.1.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >= 1.1.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/agent-pool/buildingblock/versions.tf
+++ b/modules/azuredevops/agent-pool/buildingblock/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1.1"
+      version = ">= 1.1.1"
     }
   }
 }

--- a/modules/azuredevops/pipeline/backplane/README.md
+++ b/modules/azuredevops/pipeline/backplane/README.md
@@ -53,8 +53,8 @@ module "azuredevops_pipeline_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/pipeline/backplane/versions.tf
+++ b/modules/azuredevops/pipeline/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azuredevops/pipeline/buildingblock/README.md
+++ b/modules/azuredevops/pipeline/buildingblock/README.md
@@ -182,8 +182,8 @@ steps:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.1.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >= 1.1.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/pipeline/buildingblock/versions.tf
+++ b/modules/azuredevops/pipeline/buildingblock/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1.1"
+      version = ">= 1.1.1"
     }
   }
 }

--- a/modules/azuredevops/project/backplane/README.md
+++ b/modules/azuredevops/project/backplane/README.md
@@ -68,8 +68,8 @@ To create the PAT token, you need:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/project/backplane/versions.tf
+++ b/modules/azuredevops/project/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azuredevops/project/buildingblock/README.md
+++ b/modules/azuredevops/project/buildingblock/README.md
@@ -139,8 +139,8 @@ If you get permission errors:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.1.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >= 1.1.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/project/buildingblock/versions.tf
+++ b/modules/azuredevops/project/buildingblock/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1.1"
+      version = ">= 1.1.1"
     }
   }
 }

--- a/modules/azuredevops/repository/backplane/README.md
+++ b/modules/azuredevops/repository/backplane/README.md
@@ -53,8 +53,8 @@ module "azuredevops_repository_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/repository/backplane/versions.tf
+++ b/modules/azuredevops/repository/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azuredevops/repository/buildingblock/README.md
+++ b/modules/azuredevops/repository/buildingblock/README.md
@@ -91,8 +91,8 @@ module "app_repository" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.1.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >= 1.1.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/repository/buildingblock/versions.tf
+++ b/modules/azuredevops/repository/buildingblock/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1.1"
+      version = ">= 1.1.1"
     }
   }
 }

--- a/modules/azuredevops/service-connection-subscription/backplane/README.md
+++ b/modules/azuredevops/service-connection-subscription/backplane/README.md
@@ -67,8 +67,8 @@ This eliminates the need for client secrets by using OIDC token exchange.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/service-connection-subscription/backplane/versions.tf
+++ b/modules/azuredevops/service-connection-subscription/backplane/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/azuredevops/service-connection-subscription/buildingblock/README.md
+++ b/modules/azuredevops/service-connection-subscription/buildingblock/README.md
@@ -185,9 +185,9 @@ steps:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.6.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.1.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.51.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.6.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >= 1.1.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/azuredevops/service-connection-subscription/buildingblock/versions.tf
+++ b/modules/azuredevops/service-connection-subscription/buildingblock/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.51.0"
+      version = ">= 4.51.0"
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1.1"
+      version = ">= 1.1.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.6.0"
+      version = ">= 3.6.0"
     }
   }
 }

--- a/modules/gcp/budget-alert/buildingblock/README.md
+++ b/modules/gcp/budget-alert/buildingblock/README.md
@@ -18,7 +18,7 @@ Please reference the [backplane implementation](../backplane/) for the required 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 6.12.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.12.0 |
 
 ## Modules
 
@@ -28,8 +28,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_billing_budget.budget](https://registry.terraform.io/providers/hashicorp/google/6.12.0/docs/resources/billing_budget) | resource |
-| [google_monitoring_notification_channel.notification_channel](https://registry.terraform.io/providers/hashicorp/google/6.12.0/docs/resources/monitoring_notification_channel) | resource |
+| [google_billing_budget.budget](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget) | resource |
+| [google_monitoring_notification_channel.notification_channel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
 
 ## Inputs
 

--- a/modules/gcp/budget-alert/buildingblock/versions.tf
+++ b/modules/gcp/budget-alert/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.12.0"
+      version = ">= 6.12.0"
     }
   }
 }

--- a/modules/gcp/storage-bucket/backplane/README.md
+++ b/modules/gcp/storage-bucket/backplane/README.md
@@ -66,7 +66,7 @@ This configuration will accept any subject that starts with `system:serviceaccou
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.0 |
 
 ## Modules
 

--- a/modules/gcp/storage-bucket/backplane/versions.tf
+++ b/modules/gcp/storage-bucket/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = ">= 7.0"
     }
   }
 }

--- a/modules/gcp/storage-bucket/buildingblock/README.md
+++ b/modules/gcp/storage-bucket/buildingblock/README.md
@@ -15,7 +15,7 @@ This Terraform module provisions a GCP Cloud Storage bucket with basic configura
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.0 |
 
 ## Modules
 

--- a/modules/gcp/storage-bucket/buildingblock/versions.tf
+++ b/modules/gcp/storage-bucket/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = ">= 7.0"
     }
   }
 }

--- a/modules/gcp/storage-bucket/meshstack_integration.tf
+++ b/modules/gcp/storage-bucket/meshstack_integration.tf
@@ -206,11 +206,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = ">= 7.0"
     }
   }
 }

--- a/modules/github/repository/meshstack_integration.tf
+++ b/modules/github/repository/meshstack_integration.tf
@@ -252,7 +252,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/ionos/dcd/backplane/README.md
+++ b/modules/ionos/dcd/backplane/README.md
@@ -41,7 +41,7 @@ The backplane provides outputs that can be used by building blocks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_ionoscloud"></a> [ionoscloud](#requirement\_ionoscloud) | ~> 6.4.0 |
+| <a name="requirement_ionoscloud"></a> [ionoscloud](#requirement\_ionoscloud) | >= 6.4.0 |
 
 ## Modules
 

--- a/modules/ionos/dcd/backplane/versions.tf
+++ b/modules/ionos/dcd/backplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ionoscloud = {
       source  = "ionos-cloud/ionoscloud"
-      version = "~> 6.4.0"
+      version = ">= 6.4.0"
     }
   }
 }

--- a/modules/ionos/dcd/buildingblock/README.md
+++ b/modules/ionos/dcd/buildingblock/README.md
@@ -175,7 +175,7 @@ If you get permission errors:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_ionoscloud"></a> [ionoscloud](#requirement\_ionoscloud) | ~> 6.4.0 |
+| <a name="requirement_ionoscloud"></a> [ionoscloud](#requirement\_ionoscloud) | >= 6.4.0 |
 
 ## Modules
 

--- a/modules/ionos/dcd/buildingblock/versions.tf
+++ b/modules/ionos/dcd/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ionoscloud = {
       source  = "ionos-cloud/ionoscloud"
-      version = "~> 6.4.0"
+      version = ">= 6.4.0"
     }
   }
 }

--- a/modules/ionos/user-management/buildingblock/README.md
+++ b/modules/ionos/user-management/buildingblock/README.md
@@ -146,7 +146,7 @@ This module is designed to work with the IONOS DCD module:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_ionoscloud"></a> [ionoscloud](#requirement\_ionoscloud) | ~> 6.4.0 |
+| <a name="requirement_ionoscloud"></a> [ionoscloud](#requirement\_ionoscloud) | >= 6.4.0 |
 
 ## Modules
 

--- a/modules/ionos/user-management/buildingblock/versions.tf
+++ b/modules/ionos/user-management/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ionoscloud = {
       source  = "ionos-cloud/ionoscloud"
-      version = "~> 6.4.0"
+      version = ">= 6.4.0"
     }
   }
 }

--- a/modules/kubernetes/manifest/backplane/versions.tf
+++ b/modules/kubernetes/manifest/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.35.0"
+      version = ">= 2.35.0"
     }
   }
 }

--- a/modules/kubernetes/manifest/buildingblock/README.md
+++ b/modules/kubernetes/manifest/buildingblock/README.md
@@ -11,7 +11,7 @@ description: Deploys arbitrary Kubernetes manifests into a tenant namespace via 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.17.0 |
 
 ## Modules
 

--- a/modules/kubernetes/manifest/buildingblock/versions.tf
+++ b/modules/kubernetes/manifest/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.17.0"
+      version = ">= 2.17.0"
     }
   }
 }

--- a/modules/kubernetes/manifest/meshstack_integration.tf
+++ b/modules/kubernetes/manifest/meshstack_integration.tf
@@ -202,7 +202,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/kubernetes/service-account/buildingblock/README.md
+++ b/modules/kubernetes/service-account/buildingblock/README.md
@@ -33,7 +33,7 @@ This documentation is intended as a reference for cloud foundation or platform e
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.38 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.38 |
 
 ## Modules
 

--- a/modules/kubernetes/service-account/buildingblock/versions.tf
+++ b/modules/kubernetes/service-account/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.38"
+      version = ">= 2.38"
     }
   }
 }

--- a/modules/meshstack/github-workflow/backplane/versions.tf
+++ b/modules/meshstack/github-workflow/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/modules/meshstack/github-workflow/meshstack_integration.tf
+++ b/modules/meshstack/github-workflow/meshstack_integration.tf
@@ -216,7 +216,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/meshstack/manual/meshstack_integration.tf
+++ b/modules/meshstack/manual/meshstack_integration.tf
@@ -126,7 +126,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/meshstack/noop/buildingblock/README.md
+++ b/modules/meshstack/noop/buildingblock/README.md
@@ -49,7 +49,7 @@ output "some_file_yaml" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.0 |
 
 ## Modules
 

--- a/modules/meshstack/noop/buildingblock/versions.tf
+++ b/modules/meshstack/noop/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
     # external is used to capture the AWS CLI version at apply time.
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.3.0"
+      version = ">= 2.3.0"
     }
   }
 }

--- a/modules/meshstack/noop/e2e/env-audit/buildingblock/versions.tf
+++ b/modules/meshstack/noop/e2e/env-audit/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.3.0"
+      version = ">= 2.3.0"
     }
   }
 }

--- a/modules/meshstack/noop/meshstack_integration.tf
+++ b/modules/meshstack/noop/meshstack_integration.tf
@@ -226,7 +226,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/meshstack/payment-method/buildingblock/README.md
+++ b/modules/meshstack/payment-method/buildingblock/README.md
@@ -63,7 +63,7 @@ module "payment_method" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | ~> 0.14.0 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.14.0 |
 
 ## Modules
 

--- a/modules/meshstack/payment-method/buildingblock/versions.tf
+++ b/modules/meshstack/payment-method/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0"
     }
   }
 }

--- a/modules/sapbtp/subaccounts/buildingblock/README.md
+++ b/modules/sapbtp/subaccounts/buildingblock/README.md
@@ -28,7 +28,7 @@ terraform {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_btp"></a> [btp](#requirement\_btp) | ~> 1.8.0 |
+| <a name="requirement_btp"></a> [btp](#requirement\_btp) | >= 1.8.0 |
 
 ## Modules
 

--- a/modules/sapbtp/subaccounts/buildingblock/versions.tf
+++ b/modules/sapbtp/subaccounts/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.8.0"
+      version = ">= 1.8.0"
     }
   }
 }

--- a/modules/sapbtp/subdirectory/buildingblock/README.md
+++ b/modules/sapbtp/subdirectory/buildingblock/README.md
@@ -28,7 +28,7 @@ terraform {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_btp"></a> [btp](#requirement\_btp) | ~> 1.8.0 |
+| <a name="requirement_btp"></a> [btp](#requirement\_btp) | >= 1.8.0 |
 
 ## Modules
 

--- a/modules/sapbtp/subdirectory/buildingblock/versions.tf
+++ b/modules/sapbtp/subdirectory/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.8.0"
+      version = ">= 1.8.0"
     }
   }
 }

--- a/modules/ske/forgejo-connector/buildingblock/README.md
+++ b/modules/ske/forgejo-connector/buildingblock/README.md
@@ -55,11 +55,11 @@ input containing admin credentials to the SKE cluster.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.0 |
-| <a name="requirement_forgejo"></a> [forgejo](#requirement\_forgejo) | ~> 1.3.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.35.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.8.0 |
-| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | ~> 3.0.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.0 |
+| <a name="requirement_forgejo"></a> [forgejo](#requirement\_forgejo) | >= 1.3.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.35.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.8.0 |
+| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >= 3.0.0 |
 
 ## Modules
 
@@ -71,14 +71,14 @@ input containing admin credentials to the SKE cluster.
 
 | Name | Type |
 |------|------|
-| [kubernetes_cluster_role.clusterissuer_reader](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/cluster_role) | resource |
-| [kubernetes_cluster_role_binding.forgejo_actions_clusterissuer_access](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/cluster_role_binding) | resource |
-| [kubernetes_default_service_account.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/default_service_account) | resource |
-| [kubernetes_role_binding.forgejo_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/role_binding) | resource |
-| [kubernetes_secret.additional](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
-| [kubernetes_secret.forgejo_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
-| [kubernetes_secret.image_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
-| [kubernetes_service_account.forgejo_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/service_account) | resource |
+| [kubernetes_cluster_role.clusterissuer_reader](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role_binding.forgejo_actions_clusterissuer_access](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_default_service_account.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/default_service_account) | resource |
+| [kubernetes_role_binding.forgejo_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+| [kubernetes_secret.additional](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.forgejo_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.image_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_service_account.forgejo_actions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [terraform_data.await_pipeline_workflow](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [external_external.env](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |

--- a/modules/ske/forgejo-connector/buildingblock/versions.tf
+++ b/modules/ske/forgejo-connector/buildingblock/versions.tf
@@ -2,26 +2,26 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.3.0"
+      version = ">= 2.3.0"
     }
     forgejo = {
       source  = "svalabs/forgejo"
-      version = "~> 1.3.0"
+      version = ">= 1.3.0"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.35.1"
+      version = ">= 2.35.1"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.8.0"
+      version = ">= 3.8.0"
     }
 
     restapi = {
       source  = "Mastercard/restapi"
-      version = "~> 3.0.0"
+      version = ">= 3.0.0"
     }
   }
 }

--- a/modules/ske/forgejo-connector/meshstack_integration.tf
+++ b/modules/ske/forgejo-connector/meshstack_integration.tf
@@ -266,7 +266,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/ske/ske-starterkit/buildingblock/README.md
+++ b/modules/ske/ske-starterkit/buildingblock/README.md
@@ -14,8 +14,8 @@ This building block creates a dev and prod meshStack project pair, each with a d
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | ~> 0.21.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.8.1 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.21.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.8.1 |
 
 ## Modules
 
@@ -30,8 +30,8 @@ No modules.
 | [meshstack_project.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
 | [meshstack_project_user_binding.creator_to_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
 | [meshstack_tenant_v4.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant_v4) | resource |
-| [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/3.8.1/docs/resources/string) | resource |
-| [random_uuid.binding](https://registry.terraform.io/providers/hashicorp/random/3.8.1/docs/resources/uuid) | resource |
+| [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [random_uuid.binding](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 
 ## Inputs
 

--- a/modules/ske/ske-starterkit/buildingblock/versions.tf
+++ b/modules/ske/ske-starterkit/buildingblock/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.8.1"
+      version = ">= 3.8.1"
     }
   }
 }

--- a/modules/ske/ske-starterkit/meshstack_integration.tf
+++ b/modules/ske/ske-starterkit/meshstack_integration.tf
@@ -267,7 +267,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/stackit/git-repository/backplane/README.md
+++ b/modules/stackit/git-repository/backplane/README.md
@@ -48,7 +48,7 @@ module "git_repo_backplane" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.4.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.4.0 |
 
 ## Modules
 

--- a/modules/stackit/git-repository/backplane/versions.tf
+++ b/modules/stackit/git-repository/backplane/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     http = {
       source  = "hashicorp/http"
-      version = "~> 3.4.0"
+      version = ">= 3.4.0"
     }
   }
 }

--- a/modules/stackit/git-repository/buildingblock/README.md
+++ b/modules/stackit/git-repository/buildingblock/README.md
@@ -18,10 +18,10 @@ support action variables at all. See the sub-module README for details.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.0 |
-| <a name="requirement_forgejo"></a> [forgejo](#requirement\_forgejo) | ~> 1.3.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.8.0 |
-| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | ~> 3.0.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.0 |
+| <a name="requirement_forgejo"></a> [forgejo](#requirement\_forgejo) | >= 1.3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.8.0 |
+| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >= 3.0.0 |
 
 ## Modules
 

--- a/modules/stackit/git-repository/buildingblock/action-variables-and-secrets/versions.tf
+++ b/modules/stackit/git-repository/buildingblock/action-variables-and-secrets/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     restapi = {
       source                = "Mastercard/restapi"
-      version               = "~> 3.0.0"
+      version               = ">= 3.0.0"
       configuration_aliases = [restapi.with_returned_object, restapi.without_returned_object]
     }
   }

--- a/modules/stackit/git-repository/buildingblock/versions.tf
+++ b/modules/stackit/git-repository/buildingblock/versions.tf
@@ -2,19 +2,19 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.3.0"
+      version = ">= 2.3.0"
     }
     forgejo = {
       source  = "svalabs/forgejo"
-      version = "~> 1.3.0"
+      version = ">= 1.3.0"
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "~> 3.0.0"
+      version = ">= 3.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.8.0"
+      version = ">= 3.8.0"
     }
   }
 }

--- a/modules/stackit/git-repository/meshstack_integration.tf
+++ b/modules/stackit/git-repository/meshstack_integration.tf
@@ -278,7 +278,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/modules/stackit/meshstack_integration.tf
+++ b/modules/stackit/meshstack_integration.tf
@@ -242,11 +242,11 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
     stackit = {
       source  = "stackitcloud/stackit"
-      version = "~> 0.89.0"
+      version = ">= 0.89.0"
     }
   }
 }

--- a/modules/stackit/project/backplane/README.md
+++ b/modules/stackit/project/backplane/README.md
@@ -33,7 +33,7 @@ module "project_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | ~> 0.89.0 |
+| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >= 0.89.0 |
 
 ## Modules
 

--- a/modules/stackit/project/backplane/versions.tf
+++ b/modules/stackit/project/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "stackitcloud/stackit"
-      version = "~> 0.89.0"
+      version = ">= 0.89.0"
     }
   }
 }

--- a/modules/stackit/storage-bucket/backplane/README.md
+++ b/modules/stackit/storage-bucket/backplane/README.md
@@ -38,7 +38,7 @@ module "storage_bucket_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | ~> 0.98.0 |
+| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >= 0.98.0 |
 
 ## Modules
 

--- a/modules/stackit/storage-bucket/backplane/versions.tf
+++ b/modules/stackit/storage-bucket/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "stackitcloud/stackit"
-      version = "~> 0.98.0"
+      version = ">= 0.98.0"
     }
   }
 }

--- a/modules/stackit/storage-bucket/buildingblock/README.md
+++ b/modules/stackit/storage-bucket/buildingblock/README.md
@@ -15,8 +15,8 @@ This building block module provisions a STACKIT Object Storage bucket with S3-co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
-| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | ~> 0.82.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >= 0.82.0 |
 
 ## Modules
 

--- a/modules/stackit/storage-bucket/buildingblock/versions.tf
+++ b/modules/stackit/storage-bucket/buildingblock/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     stackit = {
       source  = "stackitcloud/stackit"
-      version = "~> 0.82.0"
+      version = ">= 0.82.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/stackit/storage-bucket/meshstack_integration.tf
+++ b/modules/stackit/storage-bucket/meshstack_integration.tf
@@ -237,7 +237,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
 }

--- a/tools/scorecard/scorecard.mjs
+++ b/tools/scorecard/scorecard.mjs
@@ -135,7 +135,7 @@ const detectors = [
   {
     id: "provider_pinned",
     category: "core",
-    name: "Provider versions pinned (~>)",
+    name: "Provider versions use minimum constraint (>=)",
     emoji: "🔒",
     fn: (mod) => {
       const versionsPath = join(mod.path, "buildingblock", "versions.tf");
@@ -144,8 +144,8 @@ const detectors = [
       const versionLines = content.match(/version\s*=\s*"[^"]+"/g);
       if (!versionLines || versionLines.length === 0)
         return { pass: true, detail: "no version constraints" };
-      const allPinned = versionLines.every((l) => l.includes("~>"));
-      return { pass: allPinned };
+      const allMinimum = versionLines.every((l) => l.includes(">=") && !l.includes("~>"));
+      return { pass: allMinimum };
     },
   },
 


### PR DESCRIPTION
Reusable modules should not pin upper bounds — that responsibility belongs
to root configurations (ICF/LCF) via .terraform.lock.hcl. Using >= minimum
constraints eliminates initialization conflicts when consumers want to update
providers independently of hub module releases.

Updates scorecard check, AGENTS.md conventions, and all versions.tf /
meshstack_integration.tf files (94 files) to use >= instead of ~>.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
