### PR TITLE
fix: use eu01 region for AWS provider to fix compatibility with hashicorp/aws v6

### DIFF
--- a/modules/stackit/storage-bucket/buildingblock/provider.tf
+++ b/modules/stackit/storage-bucket/buildingblock/provider.tf
@@ -6,14 +6,14 @@ provider "stackit" {
 provider "aws" {
   access_key = var.admin_s3_access_key
   secret_key = var.admin_s3_secret_access_key
-  # Not actually relevant
-  region = "us-east-1"
+  region     = "eu01"
 
   endpoints {
     s3 = "https://object.storage.eu01.onstackit.cloud"
   }
 
   skip_credentials_validation = true
+  skip_region_validation      = true
   skip_requesting_account_id  = true
   skip_metadata_api_check     = true
   s3_use_path_style           = true


### PR DESCRIPTION
AWS provider v6 introduced enhanced region support which changed CreateBucket
to always include LocationConstraint, even for us-east-1. STACKIT Object
Storage (StorageGRID) rejects us-east-1 as an invalid location constraint.

Set region to eu01 (the STACKIT Object Storage region) so the LocationConstraint
sent matches what StorageGRID is configured to accept. Add skip_region_validation
as eu01 is not a standard AWS region name.


https://github.com/stackitcloud/terraform-provider-stackit/blob/main/docs/guides/aws_provider_s3_stackit.md

BD-2505
