### PR TITLE
fix: revert "use eu01 region for AWS provider to fix compatibility with hashicorp/aws v6"

### DIFF
--- a/modules/stackit/storage-bucket/buildingblock/provider.tf
+++ b/modules/stackit/storage-bucket/buildingblock/provider.tf
@@ -6,14 +6,14 @@ provider "stackit" {
 provider "aws" {
   access_key = var.admin_s3_access_key
   secret_key = var.admin_s3_secret_access_key
-  region     = "eu01"
+  # Not actually relevant
+  region = "us-east-1"
 
   endpoints {
     s3 = "https://object.storage.eu01.onstackit.cloud"
   }
 
   skip_credentials_validation = true
-  skip_region_validation      = true
   skip_requesting_account_id  = true
   skip_metadata_api_check     = true
   s3_use_path_style           = true


### PR DESCRIPTION
This reverts commit 0e808c131f6757789eb34cffccecc2f7d17b2480.

Unfortunately, the fix does not work. More details here: https://support.meshcloud.io/agent/tickets/2505#update-11802
