### PR TITLE
fix(gcp/storage-bucket): single console link output instead of two non-clickable URLs

### DIFF
--- a/modules/gcp/storage-bucket/buildingblock/README.md
+++ b/modules/gcp/storage-bucket/buildingblock/README.md
@@ -13,7 +13,7 @@ This Terraform module provisions a GCP Cloud Storage bucket with basic configura
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.0 |
 
@@ -24,13 +24,13 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_storage_bucket.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the storage bucket | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | List of labels to apply to the resource | `list(string)` | <pre>[<br/>  "env:dev",<br/>  "team:backend",<br/>  "project:myapp"<br/>]</pre> | no |
 | <a name="input_location"></a> [location](#input\_location) | The GCP location/region | `string` | `"europe-west1"` | no |
@@ -39,9 +39,8 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
-| <a name="output_bucket_self_link"></a> [bucket\_self\_link](#output\_bucket\_self\_link) | n/a |
 | <a name="output_bucket_url"></a> [bucket\_url](#output\_bucket\_url) | n/a |
 | <a name="output_summary"></a> [summary](#output\_summary) | Markdown summary output of the building block |
 <!-- END_TF_DOCS -->

--- a/modules/gcp/storage-bucket/buildingblock/outputs.tf
+++ b/modules/gcp/storage-bucket/buildingblock/outputs.tf
@@ -3,11 +3,7 @@ output "bucket_name" {
 }
 
 output "bucket_url" {
-  value = google_storage_bucket.main.url
-}
-
-output "bucket_self_link" {
-  value = google_storage_bucket.main.self_link
+  value = "https://console.cloud.google.com/storage/browser/${google_storage_bucket.main.name}?project=${google_storage_bucket.main.project}"
 }
 
 output "summary" {
@@ -22,8 +18,8 @@ Your GCP Storage Bucket was successfully created!
 - **Name**: ${google_storage_bucket.main.name}
 - **Project**: ${google_storage_bucket.main.project}
 - **Location**: ${google_storage_bucket.main.location}
-- **URL**: ${google_storage_bucket.main.url}
-- **Self Link**: ${google_storage_bucket.main.self_link}
+- **gsutil URI**: `${google_storage_bucket.main.url}`
+- [Open in GCP Console](https://console.cloud.google.com/storage/browser/${google_storage_bucket.main.name}?project=${google_storage_bucket.main.project})
 
 EOT
 }

--- a/modules/gcp/storage-bucket/meshstack_integration.tf
+++ b/modules/gcp/storage-bucket/meshstack_integration.tf
@@ -181,14 +181,8 @@ resource "meshstack_building_block_definition" "gcp_storage_bucket" {
       bucket_url = {
         type            = "STRING"
         assignment_type = "RESOURCE_URL"
-        display_name    = "GCP Bucket URL"
-        description     = "The URL of the created GCP bucket"
-      }
-      bucket_self_link = {
-        type            = "STRING"
-        assignment_type = "RESOURCE_URL"
-        display_name    = "GCP Bucket Self Link"
-        description     = "The self link of the created GCP bucket"
+        display_name    = "GCP Console"
+        description     = "Opens the created bucket in the GCP console"
       }
       summary = {
         type            = "STRING"


### PR DESCRIPTION
## Problem

The storage-bucket building block exposes two outputs typed `RESOURCE_URL`, and neither works as a clickable link in meshPanel:

- `bucket_url` was `gs://<bucket>`, which browsers cannot open
- `bucket_self_link` was the `https://www.googleapis.com/storage/v1/b/...` API URL, which returns JSON/401 in a browser

## Fix

- `bucket_url` now renders the GCP console deep link (`https://console.cloud.google.com/storage/browser/<bucket>?project=<project>`), displayed as "GCP Console"
- `bucket_self_link` is removed, so the building block exposes exactly one clickable resource link
- the markdown summary keeps the `gs://` URI as copyable text for gsutil users and links the console

Verified end to end on meshcloud-demo (workspace-level BBD with WIF backplane): the output opens the bucket in the console.

Note: other modules follow the same pattern (e.g. `aws/s3_bucket` outputs an ARN as `RESOURCE_URL`); happy to follow up if this direction is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)