### PR TITLE
fix: panel input import broken for optional objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ terraform {
 }
 ```
 
-<!-- scorecard-checks: variable_hub, variable_meshstack, bbd_draft, bbd_tags_forwarded -->
+<!-- scorecard-checks: variable_hub, variable_meshstack, bbd_draft, bbd_tags_forwarded, bbd_inputs_explicit_defaults -->
 ### Shared Variable Conventions
 
 The following variables must appear in every `meshstack_integration.tf`.
@@ -96,8 +96,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const   = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.
@@ -108,6 +111,8 @@ variable "hub" {
 The `const = true` attribute (OpenTofu ≥ 1.12 / Terraform ≥ 1.15) marks `var.hub` for early static evaluation during `terraform init`, which is required to interpolate `var.hub.git_ref` inside module `source` strings. `variable "hub"` must satisfy all `const` constraints:
 - Its value must come from a `default`, `.tfvars` file, or `TF_VAR_*` environment variable — **never** from a resource, data source, or dynamic local.
 - It must **not** have `sensitive = true` or `ephemeral = true`.
+
+**If a `meshstack_building_block_definition` input's `argument` field references a variable, that variable must have an explicit default** — do not rely on nested `optional()` defaults (for example via a bare `default = {}`), since some downstream consumers don't evaluate Terraform's object-attribute defaulting and would see unset fields instead. Keep the `optional()` type constraints regardless — they still document intent and protect callers who omit keys.
 
 Always use `var.hub.bbd_draft` for the `draft` field of `version_spec` in `meshstack_building_block_definition` resources.
 
@@ -342,6 +347,7 @@ See [.agents/skills/write-e2e-test/SKILL.md](.agents/skills/write-e2e-test/SKILL
 - [ ] `meshstack_integration.tf` uses `variable "hub" { type = object({git_ref = string}) }` and `variable "meshstack" { type = object({owning_workspace_identifier = string}) }`
 - [ ] `meshstack_integration.tf` references backplane via GitHub URL with `?ref=${var.hub.git_ref}` (e.g. `github.com/meshcloud/meshstack-hub//modules/<provider>/<service>/backplane?ref=${var.hub.git_ref}`) — never a hardcoded commit SHA or relative `./backplane` path
 - [ ] `variable "hub"` has `const = true`
+- [ ] Variables referenced from `meshstack_building_block_definition` input `argument` fields have explicit defaults (never rely on `optional()` defaults via bare `default = {}`)
 - [ ] `ref_name` uses `var.hub.git_ref` — no hardcoded `"main"`
 - [ ] `version_spec.draft` uses `var.hub.bbd_draft`
 - [ ] `metadata.tags = var.meshstack.tags` in `meshstack_building_block_definition` resource

--- a/modules/aks/github-connector/meshstack_integration.tf
+++ b/modules/aks/github-connector/meshstack_integration.tf
@@ -33,8 +33,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.<br>
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/aks/starterkit/meshstack_integration.tf
+++ b/modules/aks/starterkit/meshstack_integration.tf
@@ -71,8 +71,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.<br>
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/aws/route53-dns-alias-record/meshstack_integration.tf
+++ b/modules/aws/route53-dns-alias-record/meshstack_integration.tf
@@ -45,8 +45,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/aws/route53-dns-record/meshstack_integration.tf
+++ b/modules/aws/route53-dns-record/meshstack_integration.tf
@@ -45,8 +45,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/aws/s3_bucket/meshstack_integration.tf
+++ b/modules/aws/s3_bucket/meshstack_integration.tf
@@ -25,8 +25,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/azure/budget-alert/meshstack_integration.tf
+++ b/modules/azure/budget-alert/meshstack_integration.tf
@@ -44,8 +44,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/azure/resource-group/meshstack_integration.tf
+++ b/modules/azure/resource-group/meshstack_integration.tf
@@ -43,8 +43,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/azure/service-principal/meshstack_integration.tf
+++ b/modules/azure/service-principal/meshstack_integration.tf
@@ -33,8 +33,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode, which allows changing it (useful during development in LCF/ICF).

--- a/modules/azure/storage-account/meshstack_integration.tf
+++ b/modules/azure/storage-account/meshstack_integration.tf
@@ -44,8 +44,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode, which allows changing it (useful during development in LCF/ICF).

--- a/modules/gcp/storage-bucket/meshstack_integration.tf
+++ b/modules/gcp/storage-bucket/meshstack_integration.tf
@@ -25,8 +25,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/github/repository/meshstack_integration.tf
+++ b/modules/github/repository/meshstack_integration.tf
@@ -26,8 +26,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.<br>
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/kubernetes/manifest/meshstack_integration.tf
+++ b/modules/kubernetes/manifest/meshstack_integration.tf
@@ -54,8 +54,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/meshstack/github-workflow/meshstack_integration.tf
+++ b/modules/meshstack/github-workflow/meshstack_integration.tf
@@ -84,7 +84,10 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  default     = {}
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/meshstack/manual/meshstack_integration.tf
+++ b/modules/meshstack/manual/meshstack_integration.tf
@@ -11,7 +11,10 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  default     = {}
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/meshstack/noop/meshstack_integration.tf
+++ b/modules/meshstack/noop/meshstack_integration.tf
@@ -20,8 +20,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of the meshstack-hub repo.
   `bbd_draft`: If true, the building block definition version is kept in draft mode.

--- a/modules/ske/forgejo-connector/meshstack_integration.tf
+++ b/modules/ske/forgejo-connector/meshstack_integration.tf
@@ -55,8 +55,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.<br>
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/ske/ske-starterkit/meshstack_integration.tf
+++ b/modules/ske/ske-starterkit/meshstack_integration.tf
@@ -66,8 +66,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.<br>
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/stackit/git-repository/meshstack_integration.tf
+++ b/modules/stackit/git-repository/meshstack_integration.tf
@@ -40,8 +40,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.<br>
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/stackit/meshstack_integration.tf
+++ b/modules/stackit/meshstack_integration.tf
@@ -54,8 +54,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/modules/stackit/storage-bucket/meshstack_integration.tf
+++ b/modules/stackit/storage-bucket/meshstack_integration.tf
@@ -21,8 +21,11 @@ variable "hub" {
     git_ref   = optional(string, "main")
     bbd_draft = optional(bool, true)
   })
-  const       = true
-  default     = {}
+  const = true
+  default = {
+    git_ref   = "main"
+    bbd_draft = true
+  }
   description = <<-EOT
   `git_ref`: Hub release reference. Set to a tag (e.g. 'v1.2.3') or branch or commit sha of meshcloud/meshstack-hub repo.
   `bbd_draft`: If true, allows changing the building block definition for upgrading dependent building blocks.

--- a/tools/scorecard/scorecard.mjs
+++ b/tools/scorecard/scorecard.mjs
@@ -250,6 +250,54 @@ const detectors = [
     },
   },
   {
+    id: "bbd_inputs_explicit_defaults",
+    category: "integration",
+    name: "BBD input argument vars with optional() have explicit defaults",
+    emoji: "🧱",
+    fn: (mod) => {
+      const content = readIntegrationTf(mod);
+      if (!content) return { pass: false, detail: "no integration file" };
+
+      const bbdResources = extractBBDResourceBlocks(content);
+      if (bbdResources.length === 0) {
+        return { pass: null, detail: "no meshstack_building_block_definition resource" };
+      }
+
+      const referencedVars = collectBBDInputArgumentVariableReferences(content);
+      if (referencedVars.size === 0) {
+        return { pass: true, detail: "no var.* references in BBD input arguments" };
+      }
+
+      const variableBlocks = extractVariableBlocks(content);
+      const violations = [];
+
+      for (const varName of referencedVars) {
+        const variableBlock = variableBlocks.get(varName);
+        if (!variableBlock) continue;
+
+        const hasOptional = /optional\s*\(/.test(variableBlock);
+        if (!hasOptional) continue;
+
+        const hasDefault = /^\s*default\s*=/m.test(variableBlock);
+        const hasBareObjectDefault = /default\s*=\s*\{\s*\}/s.test(variableBlock);
+
+        if (!hasDefault || hasBareObjectDefault) {
+          const reason = !hasDefault ? "missing default" : "bare default = {}";
+          violations.push(`${varName} (${reason})`);
+        }
+      }
+
+      if (violations.length === 0) return { pass: true };
+
+      const shown = violations.slice(0, 5).join(", ");
+      const more = violations.length > 5 ? ` (+${violations.length - 5} more)` : "";
+      return {
+        pass: false,
+        detail: `set explicit defaults for vars referenced by BBD input arguments: ${shown}${more}`,
+      };
+    },
+  },
+  {
     id: "bbd_readme",
     category: "integration",
     name: "BBD readme field present",
@@ -571,6 +619,203 @@ function readBackplaneFile(mod, filename) {
   const p = join(mod.path, "backplane", filename);
   if (!existsSync(p)) return null;
   return readFileSync(p, "utf-8");
+}
+
+function extractBBDResourceBlocks(content) {
+  return content.match(/^resource\s+"meshstack_building_block_definition"\s+"[^"]+"\s*\{[\s\S]*?^}/gm) || [];
+}
+
+function extractVariableBlocks(content) {
+  const blocks = new Map();
+  const re = /^variable\s+"([^"]+)"\s*\{[\s\S]*?^}/gm;
+  for (const m of content.matchAll(re)) {
+    blocks.set(m[1], m[0]);
+  }
+  return blocks;
+}
+
+function findMatchingBrace(text, openingBraceIndex) {
+  if (openingBraceIndex < 0 || text[openingBraceIndex] !== "{") return -1;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = openingBraceIndex; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (inLineComment) {
+      if (ch === "\n") inLineComment = false;
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === "#") {
+      inLineComment = true;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (ch === "{") {
+      depth++;
+      continue;
+    }
+
+    if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+      if (depth < 0) return -1;
+    }
+  }
+
+  return -1;
+}
+
+function findExpressionEnd(text, startIndex) {
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+
+  for (let i = startIndex; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (inLineComment) {
+      if (ch === "\n") {
+        inLineComment = false;
+        if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) return i;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === "#") {
+      inLineComment = true;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (ch === "(") parenDepth++;
+    if (ch === ")") parenDepth = Math.max(0, parenDepth - 1);
+    if (ch === "[") bracketDepth++;
+    if (ch === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    if (ch === "{") braceDepth++;
+    if (ch === "}") braceDepth = Math.max(0, braceDepth - 1);
+
+    if (ch === "\n" && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      return i;
+    }
+  }
+
+  return text.length;
+}
+
+function collectBBDInputArgumentVariableReferences(content) {
+  const refs = new Set();
+  const resources = extractBBDResourceBlocks(content);
+
+  for (const resourceBlock of resources) {
+    const inputsRe = /inputs\s*=\s*\{/g;
+    for (const m of resourceBlock.matchAll(inputsRe)) {
+      const openingBraceIndex = m.index + m[0].lastIndexOf("{");
+      const closingBraceIndex = findMatchingBrace(resourceBlock, openingBraceIndex);
+      if (closingBraceIndex === -1) continue;
+
+      const inputsBody = resourceBlock.slice(openingBraceIndex + 1, closingBraceIndex);
+      const argumentRe = /\bargument\s*=\s*/g;
+
+      for (const argumentMatch of inputsBody.matchAll(argumentRe)) {
+        let exprStart = argumentMatch.index + argumentMatch[0].length;
+        while (exprStart < inputsBody.length && /\s/.test(inputsBody[exprStart])) exprStart++;
+        if (exprStart >= inputsBody.length) continue;
+
+        let exprEnd;
+        if (inputsBody[exprStart] === "{") {
+          const blockEnd = findMatchingBrace(inputsBody, exprStart);
+          if (blockEnd === -1) continue;
+          exprEnd = blockEnd + 1;
+        } else {
+          exprEnd = findExpressionEnd(inputsBody, exprStart);
+        }
+
+        const expression = inputsBody.slice(exprStart, exprEnd);
+        for (const varMatch of expression.matchAll(/\bvar\.([A-Za-z_][A-Za-z0-9_]*)\b/g)) {
+          refs.add(varMatch[1]);
+        }
+      }
+    }
+  }
+
+  return refs;
 }
 
 function extractBBDReadmeContent(content) {


### PR DESCRIPTION
Using optional(...) with a default of {} leads to wrong defaults when this value is referenced as a building block input default because the import only does very superficial hcl evaluation.