### PR TITLE
fix(ske/ske-starterkit): wire stackit-ai secret into forgejo-connector e2e

### DIFF
--- a/modules/ske/ske-starterkit/e2e/main.tf
+++ b/modules/ske/ske-starterkit/e2e/main.tf
@@ -46,6 +46,13 @@ variable "harbor_pull_password" {
   nullable  = false
 }
 
+variable "stackit_ai_secret_data" {
+  type        = map(string)
+  sensitive   = true
+  nullable    = false
+  description = "Data map for the 'stackit-ai' Kubernetes secret injected into tenant namespaces by the forgejo-connector (keys: STACKIT_AI_BASE_URL, STACKIT_AI_API_KEY, STACKIT_AI_MODEL)."
+}
+
 locals {
   ske_kubeconfig = jsondecode(var.ske_kubeconfig)
 }
@@ -109,6 +116,8 @@ module "forgejo_connector" {
   forgejo_repo_definition_uuid = module.stackit_git_repository.building_block_definition.uuid
   harbor_username              = var.harbor_push_username
   harbor_password              = var.harbor_push_password
+
+  additional_kubernetes_secrets = { "stackit-ai" = var.stackit_ai_secret_data }
 }
 
 module "ske_starterkit" {


### PR DESCRIPTION
## Summary

- The ske-starterkit e2e test references the `ai-summarizer` Helm chart, which requires a `stackit-ai` Kubernetes secret (`STACKIT_AI_BASE_URL`, `STACKIT_AI_API_KEY`, `STACKIT_AI_MODEL`) via `envFrom.secretRef`
- The forgejo-connector was never passed `additional_kubernetes_secrets`, so the secret was never created in the tenant namespace
- Pod failed with `CreateContainerConfigError: secret "stackit-ai" not found`
- Gap existed since May 6 but was masked until June 26 by a race in `trigger_and_await_forgejo_workflow.py` that declared success before the `deploy` job was scheduled
- Accept a `stackit_ai_secret_data` variable from the smoke-test runner and pass it to `module "forgejo_connector"` as `additional_kubernetes_secrets`; token provisioned in `meshstack-smoke-test/infra/stackit-ske`