### PR TITLE
fix(ske/ske-starterkit): widen e2e TLS probe deadline for async cert issuance

### DIFF
--- a/modules/ske/ske-starterkit/e2e/probe_endpoint.py
+++ b/modules/ske/ske-starterkit/e2e/probe_endpoint.py
@@ -20,7 +20,11 @@ import time
 import urllib.error
 import urllib.request
 
-DEADLINE_SECONDS = 180
+# cert-manager issues the ingress cert asynchronously via a Let's Encrypt HTTP-01 challenge, which
+# for a freshly-created per-run hostname routinely lands ~6-9 min after the building block reports
+# SUCCEEDED (BB completion only means the app deployed, not that the cert is ready). A 180s deadline
+# was marginal even on green runs and made the test flaky; give issuance ample head-room.
+DEADLINE_SECONDS = 600
 POLL_INTERVAL_SECONDS = 10
 REQUEST_TIMEOUT_SECONDS = 15
 
@@ -42,9 +46,16 @@ def probe(url):
                 last = str(resp.status)  # TLS ok, but not ready yet — keep retrying
         except urllib.error.HTTPError as e:
             last = str(e.code)  # TLS ok, non-2xx (app not ready yet) — keep retrying
-        except ssl.SSLCertVerificationError as e:
-            last = f"error: tls verification failed: {e.reason}"  # cert not (yet) valid
-        except (urllib.error.URLError, OSError) as e:
+        except urllib.error.URLError as e:
+            # urlopen wraps a failed TLS handshake in URLError, so a cert-verification failure
+            # surfaces here (not as a bare SSLCertVerificationError) — unwrap it for a clear
+            # message while cert-manager is still issuing the cert.
+            reason = e.reason
+            if isinstance(reason, ssl.SSLCertVerificationError):
+                last = f"error: tls verification failed: {getattr(reason, 'verify_message', None) or reason}"
+            else:
+                last = f"error: {e}"
+        except OSError as e:
             last = f"error: {e}"
         if time.monotonic() >= deadline:
             return last


### PR DESCRIPTION
## Problem

`ske/ske-starterkit` is intermittently red in the smoke-test CI (~25-35% of hourly runs; both `dev` and `prod` fail together) on:

```
data.external.app_probe["dev"/"prod"].result.status == "200"
→ <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] ... unable to get local issuer certificate>
```

## Root cause

The building block reaching `SUCCEEDED` only means the app helm-deployed — **not** that cert-manager has issued the ingress TLS cert (async Let's Encrypt HTTP-01). The probe (`e2e/probe_endpoint.py`) then polls the URL over verified TLS for only `DEADLINE_SECONDS = 180`. If the cert isn't ready, the ingress serves an untrusted cert → verification fails → test fails → auto-destroy abandons the ACME order.

**Evidence (public CT logs via [certspotter](https://api.certspotter.com/v1/issuances?domain=meshcloud-dev.stackit.run&include_subdomains=true) — hostnames embed each run's `name_suffix`, so runs map 1:1 to certs):**

- Certs are **real Let's Encrypt prod** (YR1/YR2), so the chain is fine *when a cert exists*.
- Certs for **green** runs land **~6-9 min after** the run's `name_suffix` (LE backdates `not_before` ~1h) → the 180s window was marginal *even on passing runs*.
- **Failing** runs (e.g. 2026-07-15 08:45 & 09:36) got **no cert issued at all** before the probe gave up and the app was torn down.
- **Not** a hard LE rate cap: 81 certs issued in the trailing 7 days.

## Changes

- **Raise `DEADLINE_SECONDS` 180 → 600** so async cert issuance has ample head-room. This is the primary flake fix.
- **Fix a dead `except` branch**: `urlopen` wraps TLS-handshake failures in `URLError`, so `except ssl.SSLCertVerificationError` was never reached. Unwrap `URLError.reason` to restore the intended clear `tls verification failed: <reason>` message instead of the raw `<urlopen error [SSL: ...]>` string.

## Follow-ups (not in this PR)

- Optionally gate on the cert-manager `Certificate` being `Ready` before probing (bigger change; adds a k8s dependency).
- Reduce ACME churn — the hourly cadence creates 2 brand-new certs per run; consider lowering ske frequency or reusing a stable hostname. This lives in `meshstack-smoke-test`, not the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)