### PR TITLE
feat: render better SKE + AKS Starterkit BB display names

### DIFF
--- a/modules/aks/starterkit/meshstack_integration.tf
+++ b/modules/aks/starterkit/meshstack_integration.tf
@@ -102,7 +102,7 @@ resource "meshstack_building_block_definition" "aks_starterkit" {
 
   spec = {
     description              = "The AKS Starterkit provides application teams with a pre-configured Kubernetes environment following best practices. It includes a Git repository, a CI/CD pipeline using GitHub Actions, and a secure container registry integration."
-    display_name             = "AKS Starterkit"
+    display_name             = "AKS Starterkit {{ name }}"
     notification_subscribers = var.notification_subscribers
     symbol                   = "https://raw.githubusercontent.com/meshcloud/meshstack-hub/${var.hub.git_ref}/modules/aks/starterkit/buildingblock/logo.png"
 

--- a/modules/ske/ske-starterkit/meshstack_integration.tf
+++ b/modules/ske/ske-starterkit/meshstack_integration.tf
@@ -103,7 +103,7 @@ resource "meshstack_building_block_definition" "this" {
       tenants.
     EOT
     )
-    display_name             = "SKE Starterkit"
+    display_name             = "SKE Starterkit {{ name }}"
     symbol                   = "https://raw.githubusercontent.com/meshcloud/meshstack-hub/${var.hub.git_ref}/modules/ske/ske-starterkit/buildingblock/logo.png"
     notification_subscribers = var.notification_subscribers
 


### PR DESCRIPTION
Template the building block name into the starterkit definition `display_name`
so provisioned instances render distinctly (e.g. "SKE Starterkit my-app")
instead of every instance showing the bare "SKE Starterkit" / "AKS Starterkit".

## Changes
- `modules/ske/ske-starterkit`: `display_name = "SKE Starterkit {{ name }}"`
- `modules/aks/starterkit`: `display_name = "AKS Starterkit {{ name }}"` (mirrors the SKE change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)