### PR TITLE
feat: migrate starterkit tenants to meshstack_tenant (anticipates provider v0.24.0)

### DIFF
--- a/modules/aks/starterkit/buildingblock/README.md
+++ b/modules/aks/starterkit/buildingblock/README.md
@@ -25,15 +25,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [meshstack_building_block.github_actions_dev](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block) | resource |
-| [meshstack_building_block.github_actions_prod](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block) | resource |
+| [meshstack_building_block.github_actions](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block) | resource |
 | [meshstack_building_block.repo](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block) | resource |
-| [meshstack_project.dev](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
-| [meshstack_project.prod](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
-| [meshstack_project_user_binding.creator_dev_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
-| [meshstack_project_user_binding.creator_prod_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
-| [meshstack_tenant.dev](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
-| [meshstack_tenant.prod](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
+| [meshstack_project.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
+| [meshstack_project_user_binding.creator_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
+| [meshstack_tenant.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
 | [random_id.repo_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [meshstack_platform.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/data-sources/platform) | data source |
 
@@ -53,7 +49,7 @@ No modules.
 | <a name="input_landing_zone_refs"></a> [landing\_zone\_refs](#input\_landing\_zone\_refs) | Landing zone references keyed by stage (usually dev and prod). Wired in as a static building block input from the platform/backplane that owns the meshLandingZones (their `.ref` outputs). | `map(object({ name = string, kind = optional(string, "meshLandingZone") }))` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | This name will be used for the created projects, app subdomain and GitHub repository. | `string` | n/a | yes |
 | <a name="input_platform_ref"></a> [platform\_ref](#input\_platform\_ref) | Reference (by uuid) to the meshPlatform the tenants are created on. Wired in as a static building block input from the platform/backplane that owns the meshPlatform (its `.ref` output). Required because the meshTenant v4 API references platforms by ref. | <pre>object({<br/>    uuid = string<br/>    kind = optional(string, "meshPlatform")<br/>  })</pre> | n/a | yes |
-| <a name="input_project_tags"></a> [project\_tags](#input\_project\_tags) | Tags for the created Dev/Prod projects. | <pre>object({<br/>    dev  = map(list(string))<br/>    prod = map(list(string))<br/>  })</pre> | <pre>{<br/>  "dev": {},<br/>  "prod": {}<br/>}</pre> | no |
+| <a name="input_project_tags"></a> [project\_tags](#input\_project\_tags) | Tags for the created Dev/Prod projects. | <pre>object({<br/>    dev  = map(list(string))<br/>    prod = map(list(string))<br/><br/>    owner_tag_key = optional(string, null)<br/>  })</pre> | n/a | yes |
 | <a name="input_repo_admin"></a> [repo\_admin](#input\_repo\_admin) | GitHub handle of the user who will be assigned as the repository admin. Delete building block definition input if not needed. | `string` | `null` | no |
 | <a name="input_workspace_identifier"></a> [workspace\_identifier](#input\_workspace\_identifier) | n/a | `string` | n/a | yes |
 

--- a/modules/aks/starterkit/buildingblock/README.md
+++ b/modules/aks/starterkit/buildingblock/README.md
@@ -15,7 +15,7 @@ This documentation is intended as a reference documentation for cloud foundation
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.23.0 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.24.0 |
 
 ## Modules
 
@@ -32,9 +32,10 @@ No modules.
 | [meshstack_project.prod](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
 | [meshstack_project_user_binding.creator_dev_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
 | [meshstack_project_user_binding.creator_prod_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
-| [meshstack_tenant_v4.dev](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant_v4) | resource |
-| [meshstack_tenant_v4.prod](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant_v4) | resource |
+| [meshstack_tenant.dev](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
+| [meshstack_tenant.prod](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
 | [random_id.repo_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [meshstack_platform.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/data-sources/platform) | data source |
 
 ## Inputs
 
@@ -43,16 +44,15 @@ No modules.
 | <a name="input_apps_base_domain"></a> [apps\_base\_domain](#input\_apps\_base\_domain) | Base domain used for application URLs (e.g. 'likvid-k8s.msh.host'). The app subdomain will be prefixed to this value. | `string` | `"likvid-k8s.msh.host"` | no |
 | <a name="input_archive_repo_on_destroy"></a> [archive\_repo\_on\_destroy](#input\_archive\_repo\_on\_destroy) | Whether to archive github repository when destroying the terraform resource, or delete it. Defaults to true (archive). | `bool` | `true` | no |
 | <a name="input_creator"></a> [creator](#input\_creator) | Information about the creator of the resources who will be assigned Project Admin role | <pre>object({<br/>    type        = string<br/>    identifier  = string<br/>    displayName = string<br/>    username    = optional(string)<br/>    email       = optional(string)<br/>    euid        = optional(string)<br/>  })</pre> | n/a | yes |
-| <a name="input_full_platform_identifier"></a> [full\_platform\_identifier](#input\_full\_platform\_identifier) | Full platform identifier of the AKS Namespace platform. | `string` | n/a | yes |
 | <a name="input_github_actions_connector_definition_version_uuid"></a> [github\_actions\_connector\_definition\_version\_uuid](#input\_github\_actions\_connector\_definition\_version\_uuid) | UUID of the GitHub Actions connector building block definition version. | `string` | n/a | yes |
 | <a name="input_github_org"></a> [github\_org](#input\_github\_org) | GitHub organization name. Used only for display purposes. | `string` | n/a | yes |
 | <a name="input_github_repo_definition_uuid"></a> [github\_repo\_definition\_uuid](#input\_github\_repo\_definition\_uuid) | UUID of the GitHub repository building block definition. | `string` | n/a | yes |
 | <a name="input_github_repo_definition_version_uuid"></a> [github\_repo\_definition\_version\_uuid](#input\_github\_repo\_definition\_version\_uuid) | UUID of the GitHub repository building block definition version. | `string` | n/a | yes |
 | <a name="input_github_repo_input_repo_visibility"></a> [github\_repo\_input\_repo\_visibility](#input\_github\_repo\_input\_repo\_visibility) | Visibility of the GitHub repository (e.g., public, private). | `string` | `"private"` | no |
 | <a name="input_github_template_repo_path"></a> [github\_template\_repo\_path](#input\_github\_template\_repo\_path) | GitHub repository template to use when creating the application repository, in the format 'owner/repo'. | `string` | `"likvid-bank/aks-starterkit-template"` | no |
-| <a name="input_landing_zone_dev_identifier"></a> [landing\_zone\_dev\_identifier](#input\_landing\_zone\_dev\_identifier) | AKS Landing zone identifier for the development tenant. | `string` | n/a | yes |
-| <a name="input_landing_zone_prod_identifier"></a> [landing\_zone\_prod\_identifier](#input\_landing\_zone\_prod\_identifier) | AKS Landing zone identifier for the production tenant. | `string` | n/a | yes |
+| <a name="input_landing_zone_refs"></a> [landing\_zone\_refs](#input\_landing\_zone\_refs) | Landing zone references keyed by stage (usually dev and prod). Wired in as a static building block input from the platform/backplane that owns the meshLandingZones (their `.ref` outputs). | `map(object({ name = string, kind = optional(string, "meshLandingZone") }))` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | This name will be used for the created projects, app subdomain and GitHub repository. | `string` | n/a | yes |
+| <a name="input_platform_ref"></a> [platform\_ref](#input\_platform\_ref) | Reference (by uuid) to the meshPlatform the tenants are created on. Wired in as a static building block input from the platform/backplane that owns the meshPlatform (its `.ref` output). Required because the meshTenant v4 API references platforms by ref. | <pre>object({<br/>    uuid = string<br/>    kind = optional(string, "meshPlatform")<br/>  })</pre> | n/a | yes |
 | <a name="input_project_tags"></a> [project\_tags](#input\_project\_tags) | Tags for the created Dev/Prod projects. | <pre>object({<br/>    dev  = map(list(string))<br/>    prod = map(list(string))<br/>  })</pre> | <pre>{<br/>  "dev": {},<br/>  "prod": {}<br/>}</pre> | no |
 | <a name="input_repo_admin"></a> [repo\_admin](#input\_repo\_admin) | GitHub handle of the user who will be assigned as the repository admin. Delete building block definition input if not needed. | `string` | `null` | no |
 | <a name="input_workspace_identifier"></a> [workspace\_identifier](#input\_workspace\_identifier) | n/a | `string` | n/a | yes |

--- a/modules/aks/starterkit/buildingblock/main.tf
+++ b/modules/aks/starterkit/buildingblock/main.tf
@@ -75,32 +75,51 @@ resource "meshstack_project_user_binding" "creator_prod_admin" {
   }
 }
 
-resource "meshstack_tenant_v4" "dev" {
+# Resolves the platform's full identifier (`<platform>.<location>`) from its ref, for meshPanel deep-links.
+data "meshstack_platform" "this" {
+  metadata = {
+    uuid = var.platform_ref.uuid
+  }
+}
+
+resource "meshstack_tenant" "dev" {
   metadata = {
     owned_by_workspace = var.workspace_identifier
     owned_by_project   = meshstack_project.dev.metadata.name
   }
 
   spec = {
-    platform_identifier     = var.full_platform_identifier
-    landing_zone_identifier = var.landing_zone_dev_identifier
+    platform_ref     = var.platform_ref
+    landing_zone_ref = var.landing_zone_refs["dev"]
   }
 
   depends_on = [meshstack_project_user_binding.creator_dev_admin]
 }
 
-resource "meshstack_tenant_v4" "prod" {
+resource "meshstack_tenant" "prod" {
   metadata = {
     owned_by_workspace = var.workspace_identifier
     owned_by_project   = meshstack_project.prod.metadata.name
   }
 
   spec = {
-    platform_identifier     = var.full_platform_identifier
-    landing_zone_identifier = var.landing_zone_prod_identifier
+    platform_ref     = var.platform_ref
+    landing_zone_ref = var.landing_zone_refs["prod"]
   }
 
   depends_on = [meshstack_project_user_binding.creator_prod_admin]
+}
+
+# Anticipates terraform-provider-meshstack v0.24.0 (#226): meshstack_tenant now runs on the
+# meshTenant v4 API, so meshstack_tenant_v4 usages migrate here in place (both share the v4 body).
+moved {
+  from = meshstack_tenant_v4.dev
+  to   = meshstack_tenant.dev
+}
+
+moved {
+  from = meshstack_tenant_v4.prod
+  to   = meshstack_tenant.prod
 }
 
 resource "meshstack_building_block" "repo" {
@@ -148,7 +167,7 @@ resource "meshstack_building_block" "github_actions_dev" {
     }
     target_ref = {
       kind = "meshTenant"
-      uuid = meshstack_tenant_v4.dev.metadata.uuid
+      uuid = meshstack_tenant.dev.metadata.uuid
     }
     display_name = "GHA Connector Dev"
     parent_building_blocks = [{
@@ -162,7 +181,7 @@ resource "meshstack_building_block" "github_actions_dev" {
       additional_environment_variables = {
         value = jsonencode(jsonencode({
           "DOMAIN_NAME"        = "${local.identifier}-dev"
-          "AKS_NAMESPACE_NAME" = meshstack_tenant_v4.dev.spec.platform_tenant_id
+          "AKS_NAMESPACE_NAME" = meshstack_tenant.dev.spec.platform_tenant_id
         }))
       }
     }
@@ -177,7 +196,7 @@ resource "meshstack_building_block" "github_actions_prod" {
     }
     target_ref = {
       kind = "meshTenant"
-      uuid = meshstack_tenant_v4.prod.metadata.uuid
+      uuid = meshstack_tenant.prod.metadata.uuid
     }
     parent_building_blocks = [{
       buildingblock_uuid = meshstack_building_block.repo.metadata.uuid
@@ -190,7 +209,7 @@ resource "meshstack_building_block" "github_actions_prod" {
       additional_environment_variables = {
         value = jsonencode(jsonencode({
           "DOMAIN_NAME"        = local.identifier
-          "AKS_NAMESPACE_NAME" = meshstack_tenant_v4.prod.spec.platform_tenant_id
+          "AKS_NAMESPACE_NAME" = meshstack_tenant.prod.spec.platform_tenant_id
         }))
       }
     }

--- a/modules/aks/starterkit/buildingblock/main.tf
+++ b/modules/aks/starterkit/buildingblock/main.tf
@@ -4,6 +4,12 @@ locals {
   identifier = lower(replace(replace(var.name, "/[^a-zA-Z0-9\\s\\-\\_]/", ""), "/[\\s\\-\\_]+/", "-"))
 
   repo_name = "${local.identifier}-${random_id.repo_suffix.hex}"
+
+  # GitHub Actions environment name per stage. Indexed by stage key (fails on an unknown stage).
+  github_environment_names = {
+    dev  = "development"
+    prod = "production"
+  }
 }
 
 # Generate a random suffix for the repository name to ensure uniqueness
@@ -11,30 +17,26 @@ resource "random_id" "repo_suffix" {
   byte_length = 4 // 8 hex characters
 }
 
-resource "meshstack_project" "dev" {
+resource "meshstack_project" "this" {
+  for_each = var.landing_zone_refs
+
   metadata = {
-    name               = "${local.identifier}-dev"
+    name               = "${local.identifier}-${each.key}"
     owned_by_workspace = var.workspace_identifier
   }
   spec = {
-    display_name = "${var.name} Dev"
-    tags         = var.project_tags.dev
+    display_name = "${var.name} ${title(each.key)}"
+    tags = merge(
+      var.project_tags[each.key],
+      var.project_tags.owner_tag_key == null ? {} : {
+        (var.project_tags.owner_tag_key) : [var.creator.displayName]
+      }
+    )
   }
 }
 
-resource "meshstack_project" "prod" {
-  metadata = {
-    name               = "${local.identifier}-prod"
-    owned_by_workspace = var.workspace_identifier
-  }
-  spec = {
-    display_name = "${var.name} Prod"
-    tags         = var.project_tags.prod
-  }
-}
-
-resource "meshstack_project_user_binding" "creator_dev_admin" {
-  count = var.creator.type == "User" && var.creator.username != null ? 1 : 0
+resource "meshstack_project_user_binding" "creator_admin" {
+  for_each = var.creator.type == "User" && var.creator.username != null ? var.landing_zone_refs : {}
 
   metadata = {
     name = uuid()
@@ -46,28 +48,7 @@ resource "meshstack_project_user_binding" "creator_dev_admin" {
 
   target_ref = {
     owned_by_workspace = var.workspace_identifier
-    name               = meshstack_project.dev.metadata.name
-  }
-
-  subject = {
-    name = var.creator.username
-  }
-}
-
-resource "meshstack_project_user_binding" "creator_prod_admin" {
-  count = var.creator.type == "User" && var.creator.username != null ? 1 : 0
-
-  metadata = {
-    name = uuid()
-  }
-
-  role_ref = {
-    name = "Project Admin"
-  }
-
-  target_ref = {
-    owned_by_workspace = var.workspace_identifier
-    name               = meshstack_project.prod.metadata.name
+    name               = meshstack_project.this[each.key].metadata.name
   }
 
   subject = {
@@ -82,44 +63,20 @@ data "meshstack_platform" "this" {
   }
 }
 
-resource "meshstack_tenant" "dev" {
+resource "meshstack_tenant" "this" {
+  for_each = var.landing_zone_refs
+
   metadata = {
     owned_by_workspace = var.workspace_identifier
-    owned_by_project   = meshstack_project.dev.metadata.name
+    owned_by_project   = meshstack_project.this[each.key].metadata.name
   }
 
   spec = {
     platform_ref     = var.platform_ref
-    landing_zone_ref = var.landing_zone_refs["dev"]
+    landing_zone_ref = var.landing_zone_refs[each.key]
   }
 
-  depends_on = [meshstack_project_user_binding.creator_dev_admin]
-}
-
-resource "meshstack_tenant" "prod" {
-  metadata = {
-    owned_by_workspace = var.workspace_identifier
-    owned_by_project   = meshstack_project.prod.metadata.name
-  }
-
-  spec = {
-    platform_ref     = var.platform_ref
-    landing_zone_ref = var.landing_zone_refs["prod"]
-  }
-
-  depends_on = [meshstack_project_user_binding.creator_prod_admin]
-}
-
-# Anticipates terraform-provider-meshstack v0.24.0 (#226): meshstack_tenant now runs on the
-# meshTenant v4 API, so meshstack_tenant_v4 usages migrate here in place (both share the v4 body).
-moved {
-  from = meshstack_tenant_v4.dev
-  to   = meshstack_tenant.dev
-}
-
-moved {
-  from = meshstack_tenant_v4.prod
-  to   = meshstack_tenant.prod
+  depends_on = [meshstack_project_user_binding.creator_admin]
 }
 
 resource "meshstack_building_block" "repo" {
@@ -160,76 +117,97 @@ resource "meshstack_building_block" "repo" {
   }
 }
 
-resource "meshstack_building_block" "github_actions_dev" {
+resource "meshstack_building_block" "github_actions" {
+  for_each = var.landing_zone_refs
+
   spec = {
     building_block_definition_version_ref = {
       uuid = var.github_actions_connector_definition_version_uuid
     }
     target_ref = {
       kind = "meshTenant"
-      uuid = meshstack_tenant.dev.metadata.uuid
+      uuid = meshstack_tenant.this[each.key].metadata.uuid
     }
-    display_name = "GHA Connector Dev"
+    display_name = "GHA Connector ${title(each.key)}"
     parent_building_blocks = [{
       buildingblock_uuid = meshstack_building_block.repo.metadata.uuid
       definition_uuid    = var.github_repo_definition_uuid
     }]
     inputs = {
       github_environment_name = {
-        value = jsonencode("development")
+        value = jsonencode(local.github_environment_names[each.key])
       }
       additional_environment_variables = {
         value = jsonencode(jsonencode({
-          "DOMAIN_NAME"        = "${local.identifier}-dev"
-          "AKS_NAMESPACE_NAME" = meshstack_tenant.dev.spec.platform_tenant_id
+          "DOMAIN_NAME"        = each.key == "prod" ? local.identifier : "${local.identifier}-${each.key}"
+          "AKS_NAMESPACE_NAME" = meshstack_tenant.this[each.key].spec.platform_tenant_id
         }))
       }
     }
   }
 }
 
-resource "meshstack_building_block" "github_actions_prod" {
-  spec = {
-    display_name = "GHA Connector Prod"
-    building_block_definition_version_ref = {
-      uuid = var.github_actions_connector_definition_version_uuid
-    }
-    target_ref = {
-      kind = "meshTenant"
-      uuid = meshstack_tenant.prod.metadata.uuid
-    }
-    parent_building_blocks = [{
-      buildingblock_uuid = meshstack_building_block.repo.metadata.uuid
-      definition_uuid    = var.github_repo_definition_uuid
-    }]
-    inputs = {
-      github_environment_name = {
-        value = jsonencode("production")
-      }
-      additional_environment_variables = {
-        value = jsonencode(jsonencode({
-          "DOMAIN_NAME"        = local.identifier
-          "AKS_NAMESPACE_NAME" = meshstack_tenant.prod.spec.platform_tenant_id
-        }))
-      }
-    }
-  }
-}
+# --- State address migrations (no resource recreation) ---
+# The moves are chained: hop 1 is the resource-type migration (meshTenant v4 GA rename;
+# meshstack_building_block_v2 -> meshstack_building_block), hop 2 is this PR's dev/prod -> for_each
+# address change. Terraform follows the chain, so a deployed meshstack_tenant_v4.dev migrates
+# v4 -> GA -> for_each in sequence without recreation.
 
-# Migrate the app-team-managed child building blocks from the deprecated
-# meshstack_building_block_v2 resource to meshstack_building_block in place —
-# no destroy/recreate of the live blocks.
+# Hop 1 — resource-type migrations.
+# Anticipates terraform-provider-meshstack v0.24.0 (#226): meshstack_tenant runs on the meshTenant
+# v4 API (shares the v4 body with meshstack_tenant_v4, so the move upgrades state in place).
+moved {
+  from = meshstack_tenant_v4.dev
+  to   = meshstack_tenant.dev
+}
+moved {
+  from = meshstack_tenant_v4.prod
+  to   = meshstack_tenant.prod
+}
 moved {
   from = meshstack_building_block_v2.repo
   to   = meshstack_building_block.repo
 }
-
 moved {
   from = meshstack_building_block_v2.github_actions_dev
   to   = meshstack_building_block.github_actions_dev
 }
-
 moved {
   from = meshstack_building_block_v2.github_actions_prod
   to   = meshstack_building_block.github_actions_prod
+}
+
+# Hop 2 — spelled-out dev/prod -> for_each keys (this refactor). Projects and bindings have no
+# hop-1 migration, so their move is the only hop.
+moved {
+  from = meshstack_tenant.dev
+  to   = meshstack_tenant.this["dev"]
+}
+moved {
+  from = meshstack_tenant.prod
+  to   = meshstack_tenant.this["prod"]
+}
+moved {
+  from = meshstack_project.dev
+  to   = meshstack_project.this["dev"]
+}
+moved {
+  from = meshstack_project.prod
+  to   = meshstack_project.this["prod"]
+}
+moved {
+  from = meshstack_project_user_binding.creator_dev_admin[0]
+  to   = meshstack_project_user_binding.creator_admin["dev"]
+}
+moved {
+  from = meshstack_project_user_binding.creator_prod_admin[0]
+  to   = meshstack_project_user_binding.creator_admin["prod"]
+}
+moved {
+  from = meshstack_building_block.github_actions_dev
+  to   = meshstack_building_block.github_actions["dev"]
+}
+moved {
+  from = meshstack_building_block.github_actions_prod
+  to   = meshstack_building_block.github_actions["prod"]
 }

--- a/modules/aks/starterkit/buildingblock/outputs.tf
+++ b/modules/aks/starterkit/buildingblock/outputs.tf
@@ -25,13 +25,13 @@ This starter kit has set up the following resources in workspace `${var.workspac
 
 @buildingblock[${meshstack_building_block.repo.metadata.uuid}]
 
-@project[${meshstack_project.dev.metadata.owned_by_workspace}.${meshstack_project.dev.metadata.name}]\
-&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant.dev.metadata.uuid}]\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@buildingblock[${meshstack_building_block.github_actions_dev.metadata.uuid}]
+@project[${meshstack_project.this["dev"].metadata.owned_by_workspace}.${meshstack_project.this["dev"].metadata.name}]\
+&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant.this["dev"].metadata.uuid}]\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@buildingblock[${meshstack_building_block.github_actions["dev"].metadata.uuid}]
 
-@project[${meshstack_project.prod.metadata.owned_by_workspace}.${meshstack_project.prod.metadata.name}]\
-&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant.prod.metadata.uuid}]\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@buildingblock[${meshstack_building_block.github_actions_prod.metadata.uuid}]
+@project[${meshstack_project.this["prod"].metadata.owned_by_workspace}.${meshstack_project.this["prod"].metadata.name}]\
+&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant.this["prod"].metadata.uuid}]\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@buildingblock[${meshstack_building_block.github_actions["prod"].metadata.uuid}]
 
 ---
 
@@ -69,13 +69,13 @@ View deployment status: [GitHub Actions](${jsondecode(meshstack_building_block.r
 - Check workflow status in the [Actions tab](<${jsondecode(meshstack_building_block.repo.status.outputs.repo_html_url.value)}/actions>)
 
 ### 3. Access AKS Namespaces
-- [Dev Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.dev.metadata.name}/i/${data.meshstack_platform.this.identifier}/overview/azure_kubernetes_service)
-- [Prod Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.prod.metadata.name}/i/${data.meshstack_platform.this.identifier}/overview/azure_kubernetes_service)
+- [Dev Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.this["dev"].metadata.name}/i/${data.meshstack_platform.this.identifier}/overview/azure_kubernetes_service)
+- [Prod Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.this["prod"].metadata.name}/i/${data.meshstack_platform.this.identifier}/overview/azure_kubernetes_service)
 
 ### 4. Manage Access
 - Invite team members via meshStack:
-  - [Dev Access](#/w/${var.workspace_identifier}/p/${meshstack_project.dev.metadata.name}/access-management/role-mapping)
-  - [Prod Access](#/w/${var.workspace_identifier}/p/${meshstack_project.prod.metadata.name}/access-management/role-mapping)
+  - [Dev Access](#/w/${var.workspace_identifier}/p/${meshstack_project.this["dev"].metadata.name}/access-management/role-mapping)
+  - [Prod Access](#/w/${var.workspace_identifier}/p/${meshstack_project.this["prod"].metadata.name}/access-management/role-mapping)
 
 ---
 

--- a/modules/aks/starterkit/buildingblock/outputs.tf
+++ b/modules/aks/starterkit/buildingblock/outputs.tf
@@ -26,11 +26,11 @@ This starter kit has set up the following resources in workspace `${var.workspac
 @buildingblock[${meshstack_building_block.repo.metadata.uuid}]
 
 @project[${meshstack_project.dev.metadata.owned_by_workspace}.${meshstack_project.dev.metadata.name}]\
-&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant_v4.dev.metadata.uuid}]\
+&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant.dev.metadata.uuid}]\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@buildingblock[${meshstack_building_block.github_actions_dev.metadata.uuid}]
 
 @project[${meshstack_project.prod.metadata.owned_by_workspace}.${meshstack_project.prod.metadata.name}]\
-&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant_v4.prod.metadata.uuid}]\
+&nbsp;&nbsp;&nbsp;&nbsp;@tenant[${meshstack_tenant.prod.metadata.uuid}]\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@buildingblock[${meshstack_building_block.github_actions_prod.metadata.uuid}]
 
 ---
@@ -69,8 +69,8 @@ View deployment status: [GitHub Actions](${jsondecode(meshstack_building_block.r
 - Check workflow status in the [Actions tab](<${jsondecode(meshstack_building_block.repo.status.outputs.repo_html_url.value)}/actions>)
 
 ### 3. Access AKS Namespaces
-- [Dev Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.dev.metadata.name}/i/${meshstack_tenant_v4.dev.spec.platform_identifier}/overview/azure_kubernetes_service)
-- [Prod Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.prod.metadata.name}/i/${meshstack_tenant_v4.prod.spec.platform_identifier}/overview/azure_kubernetes_service)
+- [Dev Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.dev.metadata.name}/i/${data.meshstack_platform.this.identifier}/overview/azure_kubernetes_service)
+- [Prod Namespace](/#/w/${var.workspace_identifier}/p/${meshstack_project.prod.metadata.name}/i/${data.meshstack_platform.this.identifier}/overview/azure_kubernetes_service)
 
 ### 4. Manage Access
 - Invite team members via meshStack:

--- a/modules/aks/starterkit/buildingblock/variables.tf
+++ b/modules/aks/starterkit/buildingblock/variables.tf
@@ -74,11 +74,9 @@ variable "project_tags" {
   type = object({
     dev  = map(list(string))
     prod = map(list(string))
+
+    owner_tag_key = optional(string, null)
   })
-  default = {
-    dev  = {}
-    prod = {}
-  }
   description = "Tags for the created Dev/Prod projects."
 }
 variable "github_template_repo_path" {

--- a/modules/aks/starterkit/buildingblock/variables.tf
+++ b/modules/aks/starterkit/buildingblock/variables.tf
@@ -7,19 +7,17 @@ variable "name" {
   description = "This name will be used for the created projects, app subdomain and GitHub repository."
 }
 
-variable "full_platform_identifier" {
-  type        = string
-  description = "Full platform identifier of the AKS Namespace platform."
+variable "platform_ref" {
+  type = object({
+    uuid = string
+    kind = optional(string, "meshPlatform")
+  })
+  description = "Reference (by uuid) to the meshPlatform the tenants are created on. Wired in as a static building block input from the platform/backplane that owns the meshPlatform (its `.ref` output). Required because the meshTenant v4 API references platforms by ref."
 }
 
-variable "landing_zone_dev_identifier" {
-  type        = string
-  description = "AKS Landing zone identifier for the development tenant."
-}
-
-variable "landing_zone_prod_identifier" {
-  type        = string
-  description = "AKS Landing zone identifier for the production tenant."
+variable "landing_zone_refs" {
+  type        = map(object({ name = string, kind = optional(string, "meshLandingZone") }))
+  description = "Landing zone references keyed by stage (usually dev and prod). Wired in as a static building block input from the platform/backplane that owns the meshLandingZones (their `.ref` outputs)."
 }
 
 variable "github_repo_definition_version_uuid" {

--- a/modules/aks/starterkit/buildingblock/versions.tf
+++ b/modules/aks/starterkit/buildingblock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = ">= 0.23.0"
+      version = ">= 0.24.0"
     }
   }
 }

--- a/modules/aks/starterkit/meshstack_integration.tf
+++ b/modules/aks/starterkit/meshstack_integration.tf
@@ -1,6 +1,9 @@
-variable "full_platform_identifier" {
-  type        = string
-  description = "Full identifier of the AKS platform (example: `aks.k8s`)."
+variable "platform_ref" {
+  type = object({
+    uuid = string
+    kind = optional(string, "meshPlatform")
+  })
+  description = "Reference (by uuid) to the meshPlatform tenants are created on — e.g. the `.ref` output of the meshstack_platform resource/backplane that owns it. Wired to the building block as a static input; required since the meshTenant v4 API references platforms by ref."
 }
 
 variable "github_actions_connector_definition_version_uuid" {
@@ -33,12 +36,9 @@ variable "apps_base_domain" {
   description = "Base domain used for app URLs (example: `apps.prod.example.com`)."
 }
 
-variable "landing_zone_identifiers" {
-  type = object({
-    dev  = string
-    prod = string
-  })
-  description = "Identifiers of meshLandingZones for dev and prod (example: `{ dev = \"aks-dev\", prod = \"aks-prod\" }`)."
+variable "landing_zone_refs" {
+  type        = map(object({ name = string, kind = optional(string, "meshLandingZone") }))
+  description = "Landing zone references keyed by stage (usually dev and prod), e.g. the `.ref` outputs of the meshstack_landingzone resources/backplane that owns them."
 }
 
 variable "notification_subscribers" {
@@ -175,12 +175,22 @@ EOT
         type                   = "CODE"
         updateable_by_consumer = false
       }
-      "full_platform_identifier" = {
-        argument               = jsonencode(var.full_platform_identifier)
+      "platform_ref" = {
+        # jsonencode twice is correct for structured inputs, see the project_tags input below.
+        argument               = jsonencode(jsonencode(var.platform_ref))
         assignment_type        = "STATIC"
-        display_name           = "Full Platform Identifier"
+        display_name           = "Platform Reference"
         is_environment         = false
-        type                   = "STRING"
+        type                   = "CODE"
+        updateable_by_consumer = false
+      }
+      "landing_zone_refs" = {
+        # jsonencode twice is correct for structured inputs, see the project_tags input below.
+        argument               = jsonencode(jsonencode(var.landing_zone_refs))
+        assignment_type        = "STATIC"
+        display_name           = "Landing Zone References for Dev/Prod."
+        is_environment         = false
+        type                   = "CODE"
         updateable_by_consumer = false
       }
       "github_actions_connector_definition_version_uuid" = {
@@ -237,22 +247,6 @@ EOT
         description            = "GitHub handle of the user who will be assigned as the repository admin. Leave as 'null' if not needed."
         display_name           = "Repo Admin"
         default_value          = jsonencode("null")
-        type                   = "STRING"
-        updateable_by_consumer = false
-      }
-      "landing_zone_dev_identifier" = {
-        argument               = jsonencode(var.landing_zone_identifiers.dev)
-        assignment_type        = "STATIC"
-        display_name           = "Landing Zone Dev Identifier"
-        is_environment         = false
-        type                   = "STRING"
-        updateable_by_consumer = false
-      }
-      "landing_zone_prod_identifier" = {
-        argument               = jsonencode(var.landing_zone_identifiers.prod)
-        assignment_type        = "STATIC"
-        display_name           = "Landing Zone Prod Identifier"
-        is_environment         = false
         type                   = "STRING"
         updateable_by_consumer = false
       }
@@ -337,7 +331,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = ">= 0.21.0"
+      version = ">= 0.24.0"
     }
   }
 }

--- a/modules/ske/ske-starterkit/buildingblock/README.md
+++ b/modules/ske/ske-starterkit/buildingblock/README.md
@@ -14,7 +14,7 @@ This building block creates a dev and prod meshStack project pair, each with a d
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.23.0 |
+| <a name="requirement_meshstack"></a> [meshstack](#requirement\_meshstack) | >= 0.24.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.8.1 |
 
 ## Modules
@@ -29,7 +29,7 @@ No modules.
 | [meshstack_building_block.git_repository](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block) | resource |
 | [meshstack_project.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project) | resource |
 | [meshstack_project_user_binding.creator_to_admin](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/project_user_binding) | resource |
-| [meshstack_tenant_v4.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant_v4) | resource |
+| [meshstack_tenant.this](https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/tenant) | resource |
 | [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_uuid.binding](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 
@@ -41,9 +41,9 @@ No modules.
 | <a name="input_building_block_definitions"></a> [building\_block\_definitions](#input\_building\_block\_definitions) | n/a | <pre>map(object({<br/>    uuid = string<br/>    version_ref = object({<br/>      uuid = string<br/>    })<br/>  }))</pre> | n/a | yes |
 | <a name="input_creator"></a> [creator](#input\_creator) | Information about the creator of the resources who will be assigned Project Admin role | <pre>object({<br/>    type        = string<br/>    identifier  = string<br/>    displayName = string<br/>    username    = optional(string)<br/>    email       = optional(string)<br/>    euid        = optional(string)<br/>  })</pre> | n/a | yes |
 | <a name="input_dns_zone_name"></a> [dns\_zone\_name](#input\_dns\_zone\_name) | DNS zone name used for application ingress hostnames. | `string` | n/a | yes |
-| <a name="input_full_platform_identifier"></a> [full\_platform\_identifier](#input\_full\_platform\_identifier) | Full platform identifier of the SKE platform. | `string` | n/a | yes |
-| <a name="input_landing_zone_identifiers"></a> [landing\_zone\_identifiers](#input\_landing\_zone\_identifiers) | SKE Landing zone identifiers for the dev/prod meshTenant. | <pre>object({<br/>    dev  = string<br/>    prod = string<br/>  })</pre> | n/a | yes |
+| <a name="input_landing_zone_refs"></a> [landing\_zone\_refs](#input\_landing\_zone\_refs) | Landing zone references keyed by stage (usually dev and prod). Wired in as a static building block input from the platform/backplane that owns the meshLandingZones (their `.ref` outputs). | `map(object({ name = string, kind = optional(string, "meshLandingZone") }))` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | This name will be used for the created projects. | `string` | n/a | yes |
+| <a name="input_platform_ref"></a> [platform\_ref](#input\_platform\_ref) | Reference (by uuid) to the meshPlatform the tenants are created on. Wired in as a static building block input from the platform/backplane that owns the meshPlatform (its `.ref` output). Required because the meshTenant v4 API references platforms by ref. | <pre>object({<br/>    uuid = string<br/>    kind = optional(string, "meshPlatform")<br/>  })</pre> | n/a | yes |
 | <a name="input_project_tags"></a> [project\_tags](#input\_project\_tags) | Tags for dev/prod meshProject. | <pre>object({<br/>    dev : map(list(string))<br/>    prod : map(list(string))<br/><br/>    owner_tag_key = optional(string, null)<br/>  })</pre> | n/a | yes |
 | <a name="input_repo_clone_addr"></a> [repo\_clone\_addr](#input\_repo\_clone\_addr) | URL to clone into the starterkit git repository. | `string` | n/a | yes |
 | <a name="input_workspace_identifier"></a> [workspace\_identifier](#input\_workspace\_identifier) | n/a | `string` | n/a | yes |

--- a/modules/ske/ske-starterkit/buildingblock/main.tf
+++ b/modules/ske/ske-starterkit/buildingblock/main.tf
@@ -11,7 +11,7 @@ locals {
   name           = var.add_random_name_suffix ? "${local.sanitized_name}-${random_string.name_suffix.result}" : local.sanitized_name
 
   app_hostnames = {
-    for stage, _ in var.landing_zone_identifiers :
+    for stage, _ in var.landing_zone_refs :
     stage => (
       stage == "prod"
       ? "${local.name}.${var.dns_zone_name}"
@@ -40,7 +40,7 @@ resource "meshstack_building_block" "git_repository" {
 }
 
 resource "meshstack_project" "this" {
-  for_each = tomap(var.landing_zone_identifiers)
+  for_each = var.landing_zone_refs
   metadata = {
     name               = "${local.name}-${each.key}"
     owned_by_workspace = var.workspace_identifier
@@ -56,11 +56,11 @@ resource "meshstack_project" "this" {
 }
 
 resource "random_uuid" "binding" {
-  for_each = var.creator.type == "User" && var.creator.username != null ? tomap(var.landing_zone_identifiers) : {}
+  for_each = var.creator.type == "User" && var.creator.username != null ? var.landing_zone_refs : {}
 }
 
 resource "meshstack_project_user_binding" "creator_to_admin" {
-  for_each = var.creator.type == "User" && var.creator.username != null ? tomap(var.landing_zone_identifiers) : {}
+  for_each = var.creator.type == "User" && var.creator.username != null ? var.landing_zone_refs : {}
 
   metadata = {
     name = random_uuid.binding[each.key].result
@@ -80,8 +80,8 @@ resource "meshstack_project_user_binding" "creator_to_admin" {
   }
 }
 
-resource "meshstack_tenant_v4" "this" {
-  for_each = tomap(var.landing_zone_identifiers)
+resource "meshstack_tenant" "this" {
+  for_each = var.landing_zone_refs
 
   metadata = {
     owned_by_workspace = var.workspace_identifier
@@ -89,16 +89,23 @@ resource "meshstack_tenant_v4" "this" {
   }
 
   spec = {
-    platform_identifier     = var.full_platform_identifier
-    landing_zone_identifier = each.value
+    platform_ref     = var.platform_ref
+    landing_zone_ref = each.value
   }
 
   # FIXME: remove after BD-2288 is fixed
   depends_on = [meshstack_project_user_binding.creator_to_admin]
 }
 
+# Anticipates terraform-provider-meshstack v0.24.0 (#226): meshstack_tenant now runs on the
+# meshTenant v4 API, so meshstack_tenant_v4 usages migrate here in place (both share the v4 body).
+moved {
+  from = meshstack_tenant_v4.this
+  to   = meshstack_tenant.this
+}
+
 resource "meshstack_building_block" "forgejo_connector" {
-  for_each = meshstack_tenant_v4.this
+  for_each = meshstack_tenant.this
 
   spec = {
     building_block_definition_version_ref = var.building_block_definitions["forgejo-connector"].version_ref

--- a/modules/ske/ske-starterkit/buildingblock/variables.tf
+++ b/modules/ske/ske-starterkit/buildingblock/variables.tf
@@ -19,17 +19,17 @@ variable "workspace_identifier" {
   type = string
 }
 
-variable "full_platform_identifier" {
-  type        = string
-  description = "Full platform identifier of the SKE platform."
+variable "platform_ref" {
+  type = object({
+    uuid = string
+    kind = optional(string, "meshPlatform")
+  })
+  description = "Reference (by uuid) to the meshPlatform the tenants are created on. Wired in as a static building block input from the platform/backplane that owns the meshPlatform (its `.ref` output). Required because the meshTenant v4 API references platforms by ref."
 }
 
-variable "landing_zone_identifiers" {
-  type = object({
-    dev  = string
-    prod = string
-  })
-  description = "SKE Landing zone identifiers for the dev/prod meshTenant."
+variable "landing_zone_refs" {
+  type        = map(object({ name = string, kind = optional(string, "meshLandingZone") }))
+  description = "Landing zone references keyed by stage (usually dev and prod). Wired in as a static building block input from the platform/backplane that owns the meshLandingZones (their `.ref` outputs)."
 }
 
 variable "project_tags" {

--- a/modules/ske/ske-starterkit/buildingblock/versions.tf
+++ b/modules/ske/ske-starterkit/buildingblock/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = ">= 0.23.0"
+      version = ">= 0.24.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/ske/ske-starterkit/e2e/main.tf
+++ b/modules/ske/ske-starterkit/e2e/main.tf
@@ -136,11 +136,8 @@ module "ske_starterkit" {
     bbd_draft = true
   }
 
-  full_platform_identifier = module.meshstack_kubernetes_platform.full_platform_identifier
-  landing_zone_identifiers = {
-    dev  = module.meshstack_kubernetes_platform.landing_zone_identifiers.dev
-    prod = module.meshstack_kubernetes_platform.landing_zone_identifiers.prod
-  }
+  platform_ref           = module.meshstack_kubernetes_platform.platform_ref
+  landing_zone_refs      = module.meshstack_kubernetes_platform.landing_zone_refs
   repo_clone_addr        = "https://github.com/likvid-bank/starterkit-template-stackit-ai-summarizer.git"
   dns_zone_name          = var.test_context.dns_zone_name
   add_random_name_suffix = false

--- a/modules/ske/ske-starterkit/e2e/meshstack_kubernetes_platform/outputs.tf
+++ b/modules/ske/ske-starterkit/e2e/meshstack_kubernetes_platform/outputs.tf
@@ -7,9 +7,23 @@ output "full_platform_identifier" {
   value = "${meshstack_platform.this.metadata.name}.${meshstack_platform.this.spec.location_ref.name}"
 }
 
+output "platform_ref" {
+  value = {
+    uuid = meshstack_platform.this.metadata.uuid
+    kind = "meshPlatform"
+  }
+}
+
 output "landing_zone_identifiers" {
   value = {
     dev  = meshstack_landingzone.dev.metadata.name
     prod = meshstack_landingzone.prod.metadata.name
+  }
+}
+
+output "landing_zone_refs" {
+  value = {
+    dev  = meshstack_landingzone.dev.ref
+    prod = meshstack_landingzone.prod.ref
   }
 }

--- a/modules/ske/ske-starterkit/meshstack_integration.tf
+++ b/modules/ske/ske-starterkit/meshstack_integration.tf
@@ -1,13 +1,14 @@
-variable "full_platform_identifier" {
-  type        = string
-  description = "Full identifier of the SKE platform (example: `stackit.ske`)."
+variable "platform_ref" {
+  type = object({
+    uuid = string
+    kind = optional(string, "meshPlatform")
+  })
+  description = "Reference (by uuid) to the meshPlatform tenants are created on — e.g. the `.ref` output of the meshstack_platform resource/backplane that owns it. Wired to the building block as a static input; required since the meshTenant v4 API references platforms by ref."
 }
 
-variable "landing_zone_identifiers" {
-  type = object({
-    dev  = string
-    prod = string
-  })
+variable "landing_zone_refs" {
+  type        = map(object({ name = string, kind = optional(string, "meshLandingZone") }))
+  description = "map keys are the stages, usually dev and prod"
 }
 
 variable "project_tags" {
@@ -184,18 +185,19 @@ resource "meshstack_building_block_definition" "this" {
         display_name    = "Workspace Identifier"
         description     = "Workspace where the starter kit will be provisioned."
       }
-      "full_platform_identifier" = {
-        assignment_type = "STATIC"
-        type            = "STRING"
-        display_name    = "Full Platform Identifier"
-        argument        = jsonencode(var.full_platform_identifier)
-      }
-      "landing_zone_identifiers" = {
+      "platform_ref" = {
         assignment_type = "STATIC"
         type            = "CODE"
-        display_name    = "Landing Zone Identifiers for Dev/Prod."
+        display_name    = "Platform Reference"
+        # jsonencode twice is correct for structured inputs, see landing_zone_refs below.
+        argument = jsonencode(jsonencode(var.platform_ref))
+      }
+      "landing_zone_refs" = {
+        assignment_type = "STATIC"
+        type            = "CODE"
+        display_name    = "Landing Zone References for Dev/Prod."
         # jsonencode twice is correct, see https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs/resources/building_block_definition#argument-1
-        argument = jsonencode(jsonencode(var.landing_zone_identifiers))
+        argument = jsonencode(jsonencode(var.landing_zone_refs))
       }
       "project_tags" = {
         assignment_type = "STATIC"
@@ -270,7 +272,7 @@ terraform {
   required_providers {
     meshstack = {
       source  = "meshcloud/meshstack"
-      version = ">= 0.21.0"
+      version = ">= 0.24.0"
     }
   }
 }


### PR DESCRIPTION
## Depends on: terraform-provider-meshstack **v0.24.0** release

This migration targets the ref-based `meshstack_tenant` that ships in provider **v0.24.0**, so the
touched modules bump their `meshstack` floor to `>= 0.24.0` (buildingblock `versions.tf` **and** the
`meshstack_integration.tf` `required_providers`).

**Do not merge until v0.24.0 is published to the registry.** The modules pin `>= 0.24.0`, so
consumers (IaC runtimes) can't `terraform init`/plan against them until the release is out — the
ref-based `meshstack_tenant` body and the `moved` chains only resolve on v0.24.0. Note: hub CI here
is **green** because module validation is structural (README/fmt/layout via `ci/validate_modules.sh`),
not a provider-resolving `init`/`validate`, so a green build does not imply the provider is available
yet. Provider PR stack:

- meshcloud/terraform-provider-meshstack#226 — **B0**: back `meshstack_tenant` with the meshTenant v4 API + `moved`-block migration from `meshstack_tenant_v4` (the change this PR consumes)
- meshcloud/terraform-provider-meshstack#227 — **B1** (on B0): flip the tenant client to the GA media type

Backend context (meshfed-release): the v4 tenant API landed via #10308 (merged); GA promotion is #10309.

## What

Migrates the `meshstack_tenant_v4` usages in the **aks** and **ske** starterkits to the reworked
`meshstack_tenant`, plus an aks address-management refactor:

- **`feat(aks/starterkit)`** — migrate `dev` + `prod` tenants to `meshstack_tenant`
- **`feat(ske/ske-starterkit)`** — migrate `this` (for_each over landing zones) + e2e wiring
- **`refactor(aks/starterkit)`** — drive the per-stage aks resources (projects, bindings, tenants,
  GHA connectors) with `for_each` keyed by stage instead of spelled-out `dev`/`prod`, matching the
  ske shape

Each tenant move is a non-destructive `moved { from = meshstack_tenant_v4.X, to = meshstack_tenant.X }`
(both share the v4 body, so state upgrades in place — no tenant recreate). The aks `for_each` refactor
adds `moved` blocks that map the deployed addresses **directly** to the new for_each keys in a single
hop (folding in the in-flight `meshstack_tenant_v4`→`meshstack_tenant` and
`meshstack_building_block_v2`→`meshstack_building_block` type migrations), so the address change alone
never recreates a resource.

> The **azure-virtual-machine-starterkit** is intentionally **not** included — it's slated for removal/rework.

## Ref-based body → aligned inputs

v0.24.0 references platform and landing zone **by ref**, so both starterkits now take the same two
tenant-ref inputs, wired identically as static BBD inputs (positioned together):

- `platform_ref` — `object({ uuid, kind })`, **by uuid**. Sourced from the platform/backplane that
  owns the `meshstack_platform` (its `.ref`).
- `landing_zone_refs` — `map(object({ name, kind }))` keyed by stage (dev/prod), **by name**.

This replaces the previous `full_platform_identifier` + per-stage landing-zone *identifier* inputs
(addresses the review feedback to align ske/aks and treat landing zones like `platform_ref`).
`full_platform_identifier` is dropped entirely: where it fed meshPanel deep-links, a
`meshstack_platform` data source keyed by `platform_ref.uuid` supplies the computed `.identifier`.

## Breaking change for consumers

Both starterkits replace `full_platform_identifier` + landing-zone identifier inputs with
`platform_ref` + `landing_zone_refs`. Integrations/consumers must supply the refs (e.g.
`meshstack_platform.<x>.ref`, `meshstack_landingzone.<x>.ref`).

## Notes

- READMEs regenerated with the **nix-pinned terraform-docs v0.20.0** (repo's canonical version).
- Open design point: ideally the backplane owns the meshPlatform/landing zones and exports the refs
  so the integration wires them directly — this PR takes them as static BBD inputs, the minimal
  shape of that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
