### PR TITLE
fix: source STACKIT storage-bucket e2e credentials from environment

### DIFF
--- a/modules/stackit/storage-bucket/buildingblock/README.md
+++ b/modules/stackit/storage-bucket/buildingblock/README.md
@@ -15,7 +15,7 @@ This building block module provisions a STACKIT Object Storage bucket with S3-co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 5.0 |
 | <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >= 0.82.0 |
 
 ## Modules

--- a/modules/stackit/storage-bucket/buildingblock/versions.tf
+++ b/modules/stackit/storage-bucket/buildingblock/versions.tf
@@ -11,7 +11,7 @@ terraform {
       # v5+ (SDK Go v2) always sends LocationConstraint in CreateBucket, even for us-east-1.
       # STACKIT StorageGRID only accepts requests with NO LocationConstraint (empty = us-east-1 behavior).
       # v4 (SDK Go v1) omits LocationConstraint for us-east-1, which is what StorageGRID requires.
-      version = "~> 4.0"
+      version = ">= 4.0, < 5.0"
     }
   }
 }

--- a/modules/stackit/storage-bucket/e2e/main.tf
+++ b/modules/stackit/storage-bucket/e2e/main.tf
@@ -22,16 +22,11 @@ variable "test_context" {
   nullable = false
 }
 
-variable "stackit_service_account_key" {
-  type      = string
-  sensitive = true
-  nullable  = true
-  default   = null
-}
-
 provider "stackit" {
-  service_account_key = var.stackit_service_account_key
-  experiments         = ["iam"]
+  # Credentials are picked up from the environment: STACKIT_SERVICE_ACCOUNT_KEY_PATH for local
+  # development (see meshstack-smoke-test/setup-env.sh), WIF in CI. Do not set service_account_key
+  # here — an explicit null argument overrides the env-based credential discovery.
+  experiments = ["iam"]
 }
 
 module "stackit_storage_bucket" {


### PR DESCRIPTION
## What

The `stackit/storage-bucket` e2e harness's platform-team provider hardcoded `service_account_key = var.stackit_service_account_key`. This drops the variable and the explicit argument so the STACKIT provider discovers credentials from the environment on its own:

- **Local development**: `STACKIT_SERVICE_ACCOUNT_KEY_PATH` (`~/.stackit/credentials.json`), per the standardized convention in `meshstack-smoke-test/setup-env.sh`.
- **CI**: WIF.

Passing an explicit (possibly `null`) `service_account_key` argument overrides that env-based discovery and confused the CI environment.

## Why not a "WIF fix" to the building block

The building block ([`buildingblock/provider.tf`](modules/stackit/storage-bucket/buildingblock/provider.tf)) and backplane already authenticate the STACKIT API via WIF (`use_oidc = true` + federated identity providers). Only the **e2e test harness** used a service account key — as the platform-team credential to provision the ephemeral backplane. This change touches only that harness.

`experiments = ["iam"]` stays because the inherited backplane provisions IAM resources (`stackit_authorization_project_role_assignment`, `stackit_service_account_federated_identity_provider`).

## Testing

Ran locally via `task hub:e2e:run MODULE=stackit/storage-bucket` (build-from-source mode). The provider authenticated purely from `STACKIT_SERVICE_ACCOUNT_KEY_PATH`, provisioned the backplane, ordered a real building block, and the test passed: **1 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)