### PR TITLE
fix(azure/postgresql): allow deploy role to register resource providers

### DIFF
--- a/modules/azure/postgresql/backplane/main.tf
+++ b/modules/azure/postgresql/backplane/main.tf
@@ -4,6 +4,9 @@ resource "azurerm_role_definition" "buildingblock_deploy" {
   scope       = var.scope
   permissions {
     actions = [
+      # resource manager
+      "*/register/action",
+      # postgresql
       "Microsoft.DBforPostgreSQL/servers/write",
       "Microsoft.DBforPostgreSQL/servers/read",
       "Microsoft.DBforPostgreSQL/servers/delete",


### PR DESCRIPTION
The PostgreSQL building block deploy role only granted Microsoft.DBforPostgreSQL/* actions. On a freshly created subscription the DBforPostgreSQL resource provider is not yet registered, and the first deployment fails because the deploy role cannot register it.

Add "*/register/action" so the deploy role can register the required resource providers, matching the pattern already used by the other Azure backplane modules (e.g. storage-account, key-vault).

Florian says this is iimportant.