### PR TITLE
fix: migrate federated identity credential to azurerm v5 schema

### DIFF
--- a/modules/azure/budget-alert/backplane/README.md
+++ b/modules/azure/budget-alert/backplane/README.md
@@ -12,7 +12,7 @@ across all subscriptions underneath a management group (typically the top-level 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.64.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.65.0 |
 
 ## Modules
 

--- a/modules/azure/budget-alert/backplane/main.tf
+++ b/modules/azure/budget-alert/backplane/main.tf
@@ -12,12 +12,11 @@ resource "azurerm_user_assigned_identity" "backplane" {
 resource "azurerm_federated_identity_credential" "backplane" {
   for_each = { for i, s in var.workload_identity_federation.subjects : tostring(i) => s }
 
-  name                = "subject-${each.key}"
-  resource_group_name = azurerm_resource_group.backplane.name
-  parent_id           = azurerm_user_assigned_identity.backplane.id
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = var.workload_identity_federation.issuer
-  subject             = each.value
+  name                      = "subject-${each.key}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.backplane.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = var.workload_identity_federation.issuer
+  subject                   = each.value
 }
 
 resource "azurerm_role_definition" "backplane" {

--- a/modules/azure/budget-alert/backplane/versions.tf
+++ b/modules/azure/budget-alert/backplane/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.64.0"
+      version = ">= 4.65.0"
     }
   }
 }

--- a/modules/azure/entra-id-groups/backplane/main.tf
+++ b/modules/azure/entra-id-groups/backplane/main.tf
@@ -12,12 +12,11 @@ resource "azurerm_user_assigned_identity" "this" {
 resource "azurerm_federated_identity_credential" "this" {
   for_each = { for i, s in var.workload_identity_federation.subjects : tostring(i) => s }
 
-  name                = "subject-${each.key}"
-  resource_group_name = azurerm_resource_group.this.name
-  parent_id           = azurerm_user_assigned_identity.this.id
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = var.workload_identity_federation.issuer
-  subject             = each.value
+  name                      = "subject-${each.key}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.this.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = var.workload_identity_federation.issuer
+  subject                   = each.value
 }
 
 # Grant Microsoft Graph app roles so the UAMI can read users, manage groups, and manage Administrative Unit members.

--- a/modules/azure/entra-id-groups/backplane/versions.tf
+++ b/modules/azure/entra-id-groups/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.0"
+      version = ">= 4.65.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/azure/github-actions-terraform-setup/buildingblock/README.md
+++ b/modules/azure/github-actions-terraform-setup/buildingblock/README.md
@@ -24,7 +24,7 @@ For more information, refer to the backplane documentation of the [Azure GitHub 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.4.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.65.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.3 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11.1 |

--- a/modules/azure/github-actions-terraform-setup/buildingblock/resources.azure.cicd.tf
+++ b/modules/azure/github-actions-terraform-setup/buildingblock/resources.azure.cicd.tf
@@ -40,8 +40,7 @@ resource "azurerm_user_assigned_identity" "ghactions" {
 
 # see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure#adding-the-federated-credentials-to-azure
 resource "azurerm_federated_identity_credential" "ghactions" {
-  parent_id           = azurerm_user_assigned_identity.ghactions.id
-  resource_group_name = azurerm_resource_group.cicd.name
+  user_assigned_identity_id = azurerm_user_assigned_identity.ghactions.id
 
   name     = "github-actions"
   audience = ["api://AzureADTokenExchange"]

--- a/modules/azure/github-actions-terraform-setup/buildingblock/versions.tf
+++ b/modules/azure/github-actions-terraform-setup/buildingblock/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.4.0"
+      version = ">= 4.65.0"
     }
 
     azuread = {

--- a/modules/azure/resource-group/backplane/main.tf
+++ b/modules/azure/resource-group/backplane/main.tf
@@ -12,12 +12,11 @@ resource "azurerm_user_assigned_identity" "backplane" {
 resource "azurerm_federated_identity_credential" "backplane" {
   for_each = { for i, s in var.workload_identity_federation.subjects : tostring(i) => s }
 
-  name                = "subject-${each.key}"
-  resource_group_name = azurerm_resource_group.backplane.name
-  parent_id           = azurerm_user_assigned_identity.backplane.id
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = var.workload_identity_federation.issuer
-  subject             = each.value
+  name                      = "subject-${each.key}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.backplane.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = var.workload_identity_federation.issuer
+  subject                   = each.value
 }
 
 resource "azurerm_role_definition" "backplane" {

--- a/modules/azure/resource-group/backplane/versions.tf
+++ b/modules/azure/resource-group/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.64.0"
+      version = ">= 4.65.0"
     }
   }
 }

--- a/modules/azure/storage-account/backplane/README.md
+++ b/modules/azure/storage-account/backplane/README.md
@@ -108,7 +108,7 @@ module "storage_account_backplane" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.64 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.65.0 |
 
 ## Modules
 

--- a/modules/azure/storage-account/backplane/main.tf
+++ b/modules/azure/storage-account/backplane/main.tf
@@ -12,12 +12,11 @@ resource "azurerm_user_assigned_identity" "backplane" {
 resource "azurerm_federated_identity_credential" "backplane" {
   for_each = { for i, s in var.workload_identity_federation.subjects : tostring(i) => s }
 
-  name                = "subject-${each.key}"
-  resource_group_name = azurerm_resource_group.backplane.name
-  parent_id           = azurerm_user_assigned_identity.backplane.id
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = var.workload_identity_federation.issuer
-  subject             = each.value
+  name                      = "subject-${each.key}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.backplane.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = var.workload_identity_federation.issuer
+  subject                   = each.value
 }
 
 resource "azurerm_role_definition" "backplane" {

--- a/modules/azure/storage-account/backplane/versions.tf
+++ b/modules/azure/storage-account/backplane/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.64"
+      version = ">= 4.65.0"
     }
   }
 }


### PR DESCRIPTION
azurerm v5 removed `parent_id`/`resource_group_name` in favour of `user_assigned_identity_id`, which landed in 4.65.0 — hence the floor bump.