### PR TITLE
feat(website): fullscreen zoom viewer for architecture diagrams

### DIFF
--- a/website/src/app/features/reference-architecture-detail/reference-architecture-detail.component.html
+++ b/website/src/app/features/reference-architecture-detail/reference-architecture-detail.component.html
@@ -96,7 +96,7 @@
       <div>
         <mst-card label="Architecture Details" class="w-full">
           <div class="p-6 md:p-8" card-body>
-            <div class="prose prose-slate max-w-none
+            <div class="markdown-body prose prose-slate max-w-none
                         prose-headings:text-slate-900
                         prose-h2:text-xl prose-h2:font-bold prose-h2:mt-8 prose-h2:mb-4
                         prose-h3:text-lg prose-h3:font-semibold prose-h3:mt-6 prose-h3:mb-3

--- a/website/src/app/features/reference-architecture-detail/reference-architecture-detail.component.scss
+++ b/website/src/app/features/reference-architecture-detail/reference-architecture-detail.component.scss
@@ -1,5 +1,6 @@
-/* Mermaid diagrams rendered inside [innerHTML] need :host ::ng-deep to pierce encapsulation */
-:host ::ng-deep .mermaid-diagram {
+/* Diagrams live inside [innerHTML] content, so styling them needs :host ::ng-deep */
+:host ::ng-deep .diagram-figure {
+  position: relative;
   display: flex;
   justify-content: center;
   margin: 1.5rem 0;
@@ -7,11 +8,41 @@
   background-color: #f8fafc; /* slate-50 */
   border: 1px solid #e2e8f0; /* slate-200 */
   border-radius: 0.75rem;
-  overflow-x: auto;
+  cursor: zoom-in;
+  transition: border-color 0.15s ease;
 
+  &:hover {
+    border-color: #94a3b8; /* slate-400 */
+  }
+
+  img,
   svg {
     max-width: 100%;
     height: auto;
   }
-}
 
+  .diagram-expand {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: #475569; /* slate-600 */
+    background-color: rgb(255 255 255 / 0.9);
+    border: 1px solid #e2e8f0; /* slate-200 */
+    border-radius: 0.375rem;
+    /* Kept visible rather than hover-only so the affordance also exists on touch devices */
+    opacity: 0.75;
+    transition: opacity 0.15s ease, color 0.15s ease;
+  }
+
+  &:hover .diagram-expand,
+  .diagram-expand:focus-visible {
+    opacity: 1;
+    color: #0f172a; /* slate-900 */
+  }
+}

--- a/website/src/app/features/reference-architecture-detail/reference-architecture-detail.component.ts
+++ b/website/src/app/features/reference-architecture-detail/reference-architecture-detail.component.ts
@@ -9,6 +9,7 @@ import { ReferenceArchitecture, SeoService } from 'app/core';
 import { BreadcrumbComponent } from 'app/shared/breadcrumb';
 import { BreadcrumbItem } from 'app/shared/breadcrumb/breadcrumb';
 import { CardComponent } from 'app/shared/card';
+import { DiagramViewerComponent } from 'app/shared/diagram-viewer';
 import { Platform, PlatformService } from 'app/shared/platform';
 import { ReferenceArchitectureService } from 'app/shared/reference-architecture';
 import { TemplateService } from 'app/shared/template';
@@ -104,14 +105,14 @@ export class ReferenceArchitectureDetailComponent implements OnInit, OnDestroy, 
       'code.language-mermaid:not([data-mermaid-rendered])'
     );
 
-    if (mermaidBlocks.length === 0) {
-      return;
+    if (mermaidBlocks.length > 0) {
+      // Mark blocks synchronously before the async render to prevent double-processing
+      // when ngAfterViewChecked fires again during the async mermaid import.
+      mermaidBlocks.forEach((block: Element) => block.setAttribute('data-mermaid-rendered', 'true'));
+      this.renderMermaid(mermaidBlocks);
     }
 
-    // Mark blocks synchronously before the async render to prevent double-processing
-    // when ngAfterViewChecked fires again during the async mermaid import.
-    mermaidBlocks.forEach((block: Element) => block.setAttribute('data-mermaid-rendered', 'true'));
-    this.renderMermaid(mermaidBlocks);
+    this.enhanceDiagramImages();
   }
 
   public ngOnDestroy(): void {
@@ -186,14 +187,78 @@ export class ReferenceArchitectureDetailComponent implements OnInit, OnDestroy, 
 
       try {
         const { svg } = await mermaid.render(id, graphDefinition);
-        const wrapper = document.createElement('div');
-        wrapper.classList.add('mermaid-diagram');
-        wrapper.innerHTML = svg;
-        pre.replaceWith(wrapper);
+        const holder = document.createElement('div');
+        holder.innerHTML = svg;
+        const svgEl = holder.firstElementChild as HTMLElement | null;
+
+        if (!svgEl) {
+          continue;
+        }
+
+        pre.replaceWith(svgEl);
+        this.makeZoomable(svgEl, svgEl, 'Diagram', null);
       } catch {
         // Leave the code block as-is if rendering fails
       }
     }
+  }
+
+  /**
+   * Diagrams in the markdown body are committed SVGs referenced as images. They are wide and
+   * detailed, and browser zoom does not help — the page just reflows and the diagram stays fitted
+   * to its column — so each one gets a fullscreen viewer with real zoom and pan.
+   */
+  private enhanceDiagramImages(): void {
+    const images: NodeListOf<HTMLImageElement> = this.el.nativeElement.querySelectorAll(
+      '.markdown-body img:not([data-diagram-enhanced])'
+    );
+
+    images.forEach(img =>
+      this.makeZoomable(img, img, img.getAttribute('alt') || 'Diagram', img.getAttribute('src'))
+    );
+  }
+
+  /**
+   * Wraps `element` in a figure carrying a fullscreen affordance. `viewerNode` is what the viewer
+   * clones and displays — the same element for images, the bare `<svg>` for rendered mermaid.
+   */
+  private makeZoomable(
+    element: HTMLElement,
+    viewerNode: HTMLElement,
+    title: string,
+    sourceUrl: string | null
+  ): void {
+    element.setAttribute('data-diagram-enhanced', 'true');
+
+    const figure = document.createElement('figure');
+    figure.className = 'diagram-figure';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'diagram-expand';
+    button.setAttribute('aria-label', `View ${title} fullscreen`);
+    button.innerHTML = '<i class="fa-solid fa-expand"></i><span>Fullscreen</span>';
+
+    // A markdown image sits alone in its own paragraph — replace that paragraph so the figure does
+    // not end up nested inside a <p>.
+    const parent = element.parentElement;
+    const replaced =
+      parent?.tagName === 'P' && parent.childElementCount === 1 && !parent.textContent?.trim()
+        ? parent
+        : element;
+
+    replaced.parentElement?.replaceChild(figure, replaced);
+    figure.appendChild(element);
+    figure.appendChild(button);
+
+    figure.addEventListener('click', () => this.openDiagram(viewerNode, title, sourceUrl));
+  }
+
+  private openDiagram(node: HTMLElement, title: string, sourceUrl: string | null): void {
+    this.dialog.open(DiagramViewerComponent, {
+      panelClass: 'diagram-viewer-panel',
+      data: { title, node, sourceUrl }
+    });
   }
 }
 

--- a/website/src/app/shared/diagram-viewer/diagram-viewer.component.html
+++ b/website/src/app/shared/diagram-viewer/diagram-viewer.component.html
@@ -1,0 +1,76 @@
+<div class="diagram-viewer fixed inset-0 flex flex-col bg-slate-900">
+  <!-- Toolbar -->
+  <div class="flex items-center gap-3 px-4 py-3 border-b border-white/10 text-slate-100">
+    <i class="fa-solid fa-diagram-project text-primary-300"></i>
+    <span class="text-sm font-semibold truncate flex-1">{{ data.title }}</span>
+
+    <div class="flex items-center gap-1 rounded-lg bg-white/10 p-1">
+      <button
+        type="button"
+        class="diagram-viewer-btn"
+        aria-label="Zoom out"
+        title="Zoom out (-)"
+        (click)="zoomOut()">
+        <i class="fa-solid fa-magnifying-glass-minus"></i>
+      </button>
+      <span class="w-14 text-center text-xs font-mono tabular-nums">{{ zoomPercent }}%</span>
+      <button
+        type="button"
+        class="diagram-viewer-btn"
+        aria-label="Zoom in"
+        title="Zoom in (+)"
+        (click)="zoomIn()">
+        <i class="fa-solid fa-magnifying-glass-plus"></i>
+      </button>
+      <button
+        type="button"
+        class="diagram-viewer-btn"
+        aria-label="Fit to screen"
+        title="Fit to screen (0)"
+        (click)="resetView()">
+        <i class="fa-solid fa-compress"></i>
+      </button>
+    </div>
+
+    <a
+      *ngIf="data.sourceUrl"
+      [href]="data.sourceUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="diagram-viewer-btn text-slate-100"
+      aria-label="Open diagram in a new tab"
+      title="Open diagram in a new tab">
+      <i class="fa-solid fa-up-right-from-square"></i>
+    </a>
+
+    <button
+      type="button"
+      class="diagram-viewer-btn text-slate-100"
+      aria-label="Close"
+      title="Close (Esc)"
+      (click)="dialogRef.close()">
+      <i class="fa-solid fa-xmark text-lg"></i>
+    </button>
+  </div>
+
+  <!-- Stage -->
+  <div
+    #stage
+    class="diagram-viewer-stage flex-1 overflow-hidden"
+    [class.is-panning]="panning"
+    (pointerdown)="onPointerDown($event)"
+    (pointermove)="onPointerMove($event)"
+    (pointerup)="onPointerUp($event)"
+    (pointercancel)="onPointerUp($event)"
+    (dblclick)="onDoubleClick($event)">
+    <div
+      #canvas
+      class="diagram-viewer-canvas"
+      [style.transform]="'translate(' + translateX + 'px, ' + translateY + 'px)'">
+    </div>
+  </div>
+
+  <div class="px-4 py-2 text-center text-xs text-slate-400 border-t border-white/10">
+    Scroll or pinch to zoom · drag to pan · double-click to zoom · Esc to close
+  </div>
+</div>

--- a/website/src/app/shared/diagram-viewer/diagram-viewer.component.scss
+++ b/website/src/app/shared/diagram-viewer/diagram-viewer.component.scss
@@ -1,0 +1,46 @@
+.diagram-viewer-stage {
+  position: relative;
+  touch-action: none;
+  cursor: grab;
+
+  &.is-panning {
+    cursor: grabbing;
+  }
+}
+
+.diagram-viewer-canvas {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+.diagram-viewer-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: rgb(255 255 255 / 0.15);
+  }
+}
+
+/* The diagram is cloned into the canvas at runtime, so it carries no component style attribute. */
+:host ::ng-deep .diagram-viewer-content {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  user-select: none;
+  pointer-events: none;
+  background-color: #ffffff;
+  border-radius: 0.5rem;
+}

--- a/website/src/app/shared/diagram-viewer/diagram-viewer.component.ts
+++ b/website/src/app/shared/diagram-viewer/diagram-viewer.component.ts
@@ -1,0 +1,222 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { CommonModule } from '@angular/common';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  HostListener,
+  Inject,
+  ViewChild
+} from '@angular/core';
+
+export interface DiagramViewerData {
+  /** Title shown in the viewer toolbar. */
+  title: string;
+  /** The diagram to display — an `<img>` or `<svg>` element. It is cloned, never moved. */
+  node: HTMLElement;
+  /** Source URL of the diagram, when it has one. Enables "open original". */
+  sourceUrl?: string | null;
+}
+
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 16;
+const ZOOM_STEP = 1.25;
+
+/**
+ * Fullscreen diagram viewer with zoom and pan. Architecture diagrams are wide and detailed, so
+ * browser zoom does not help: the page reflows and the diagram stays fitted to its column.
+ */
+@Component({
+  selector: 'mst-diagram-viewer',
+  imports: [CommonModule],
+  templateUrl: './diagram-viewer.component.html',
+  styleUrl: './diagram-viewer.component.scss',
+  standalone: true
+})
+export class DiagramViewerComponent implements AfterViewInit {
+  @ViewChild('canvas', { static: true })
+  public canvas!: ElementRef<HTMLElement>;
+
+  @ViewChild('stage', { static: true })
+  public stage!: ElementRef<HTMLElement>;
+
+  public scale = 1;
+
+  public translateX = 0;
+
+  public translateY = 0;
+
+  public panning = false;
+
+  private pointerId: number | null = null;
+
+  private panStartX = 0;
+
+  private panStartY = 0;
+
+  private content: HTMLElement | null = null;
+
+  /** Size the diagram renders at when fitted to the stage — the 100% zoom reference. */
+  private baseWidth = 0;
+
+  private baseHeight = 0;
+
+  constructor(
+    public dialogRef: DialogRef<DiagramViewerComponent>,
+    @Inject(DIALOG_DATA) public data: DiagramViewerData
+  ) {}
+
+  public get zoomPercent(): number {
+    return Math.round(this.scale * 100);
+  }
+
+  public ngAfterViewInit(): void {
+    const clone = this.data.node.cloneNode(true) as HTMLElement;
+    clone.removeAttribute('data-diagram-enhanced');
+    clone.classList.add('diagram-viewer-content');
+    this.canvas.nativeElement.appendChild(clone);
+    this.content = clone;
+
+    if (clone instanceof HTMLImageElement && !clone.complete) {
+      clone.addEventListener('load', () => this.captureBaseSize(), { once: true });
+
+      return;
+    }
+
+    this.captureBaseSize();
+  }
+
+  public zoomIn(): void {
+    this.zoomBy(ZOOM_STEP);
+  }
+
+  public zoomOut(): void {
+    this.zoomBy(1 / ZOOM_STEP);
+  }
+
+  /** Back to "fits the viewport" — the state the viewer opens in. */
+  public resetView(): void {
+    this.scale = 1;
+    this.translateX = 0;
+    this.translateY = 0;
+    this.applyScale();
+  }
+
+  @HostListener('wheel', ['$event'])
+  public onWheel(event: WheelEvent): void {
+    event.preventDefault();
+    // Trackpad pinch arrives as a wheel event with ctrlKey set; both gestures zoom.
+    const factor = Math.pow(ZOOM_STEP, -event.deltaY / 100);
+    this.zoomBy(factor, event.clientX, event.clientY);
+  }
+
+  public onPointerDown(event: PointerEvent): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    this.pointerId = event.pointerId;
+    this.panning = true;
+    this.panStartX = event.clientX - this.translateX;
+    this.panStartY = event.clientY - this.translateY;
+    (event.target as HTMLElement).setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+  }
+
+  public onPointerMove(event: PointerEvent): void {
+    if (!this.panning || event.pointerId !== this.pointerId) {
+      return;
+    }
+
+    this.translateX = event.clientX - this.panStartX;
+    this.translateY = event.clientY - this.panStartY;
+  }
+
+  public onPointerUp(event: PointerEvent): void {
+    if (event.pointerId !== this.pointerId) {
+      return;
+    }
+
+    this.panning = false;
+    this.pointerId = null;
+  }
+
+  public onDoubleClick(event: MouseEvent): void {
+    if (this.scale > 1) {
+      this.resetView();
+
+      return;
+    }
+
+    this.zoomBy(ZOOM_STEP * ZOOM_STEP, event.clientX, event.clientY);
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  public onKeydown(event: KeyboardEvent): void {
+    if (event.key === '+' || event.key === '=') {
+      this.zoomIn();
+    } else if (event.key === '-' || event.key === '_') {
+      this.zoomOut();
+    } else if (event.key === '0') {
+      this.resetView();
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+  }
+
+  /**
+   * Scales by `factor`, keeping the point under the cursor fixed. Without an anchor the stage
+   * centre stays put, which is what the toolbar buttons want.
+   */
+  private zoomBy(factor: number, anchorClientX?: number, anchorClientY?: number): void {
+    const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, this.scale * factor));
+    const applied = next / this.scale;
+
+    if (applied === 1) {
+      return;
+    }
+
+    if (anchorClientX !== undefined && anchorClientY !== undefined) {
+      const rect = this.stage.nativeElement.getBoundingClientRect();
+      // Transform origin is the stage centre, so anchor offsets are measured from there.
+      const anchorX = anchorClientX - (rect.left + rect.width / 2);
+      const anchorY = anchorClientY - (rect.top + rect.height / 2);
+      this.translateX = anchorX - (anchorX - this.translateX) * applied;
+      this.translateY = anchorY - (anchorY - this.translateY) * applied;
+    }
+
+    this.scale = next;
+    this.applyScale();
+  }
+
+  private captureBaseSize(): void {
+    if (!this.content) {
+      return;
+    }
+
+    const rect = this.content.getBoundingClientRect();
+    this.baseWidth = rect.width;
+    this.baseHeight = rect.height;
+    // The fit is now pinned as an explicit size, so the fit constraints have to go.
+    this.content.style.maxWidth = 'none';
+    this.content.style.maxHeight = 'none';
+    this.applyScale();
+  }
+
+  /**
+   * Zoom changes the diagram's layout size rather than applying a `scale()` transform: a
+   * transform would rasterize the SVG once at fit size and blow up that bitmap, which is exactly
+   * the blurry result users already get from browser zoom. Resizing makes the browser re-render
+   * the vector, so text stays sharp at any zoom level.
+   */
+  private applyScale(): void {
+    if (!this.content || !this.baseWidth) {
+      return;
+    }
+
+    this.content.style.width = `${this.baseWidth * this.scale}px`;
+    this.content.style.height = `${this.baseHeight * this.scale}px`;
+  }
+}

--- a/website/src/app/shared/diagram-viewer/index.ts
+++ b/website/src/app/shared/diagram-viewer/index.ts
@@ -1,0 +1,1 @@
+export * from './diagram-viewer.component';


### PR DESCRIPTION
## Problem

Users can't zoom into architecture diagrams on reference architecture pages. Browser zoom doesn't help — the page just reflows and the diagram stays fitted to its (fairly narrow) content column. Zooming an `<img>` of an SVG via browser zoom also rasterizes it, so labels go blurry.

## What this does

Every image in a reference architecture's markdown body is wrapped in a figure with a small **Fullscreen** affordance. Clicking it opens a new shared `mst-diagram-viewer` dialog that fills the viewport:

- zoom via scroll wheel / trackpad pinch (anchored at the cursor), toolbar buttons, double-click, and `+` / `-` / `0` — 25%–1600%
- drag to pan, `Esc` to close, live zoom-% readout
- a button to open the raw SVG in a new tab

**Zoom resizes the diagram's layout box instead of applying `transform: scale()`.** A transform would rasterize the SVG once at fit size and blow that bitmap up — exactly the blurry result browser zoom already gives. Resizing makes the browser re-render the vector, so text stays sharp at 500%.

Mermaid-rendered diagrams (still supported by the detail page, though reference architectures now commit DOT/SVG) go through the same path and hand the live `<svg>` to the viewer.

The affordance is always visible rather than hover-only, so it also exists on touch devices.

## Verification

Driven in Chrome against the dev server on the STACKIT Landing Zone page:

- figure + button render, viewer opens with the SVG
- wheel zoom reached 499% and stayed crisp
- drag-pan applied the expected translate, `0` reset the view, `Esc` closed the viewer and left the page diagram intact
- injected a mermaid block to exercise that path: renders, wraps, opens as a live `<svg>`, resizes on zoom

`ng build` passes. `ng lint` reports the same 27 pre-existing errors with and without this change.

## Review notes

Left as draft — worth a look at the viewer chrome (toolbar/hint bar styling) before merging, and it's only wired into the reference architecture detail page, the one place that currently renders markdown bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)