### PR TITLE
chore(meshstack): declare manual needs no backplane

### DIFF
--- a/modules/meshstack/manual/buildingblock/README.md
+++ b/modules/meshstack/manual/buildingblock/README.md
@@ -5,6 +5,8 @@ supportedPlatforms:
 description: |
   Reference building block demonstrating meshStack's MANUAL implementation type:
   the backend derives one output per input, translating types that cannot be outputs.
+# MANUAL implementation type: no Terraform runs at all, so there is nothing to set up cloud-side.
+requiresBackplane: false
 ---
 # meshStack Manual Building Block
 


### PR DESCRIPTION
Applies the `requiresBackplane: false` opt-out introduced in #245 to `meshstack/manual`.

The manual building block uses the `MANUAL` implementation type (`implementation = { manual = {} }`) — no Terraform runs at all, and the module has no `buildingblock/*.tf` files. There is nothing to provision or grant cloud-side, so the absent `backplane/` tier is a semantic mismatch rather than a gap.

Scorecard Testing goes 🟡 67% → 🟢 100%, overall 77% → 81%. Repo-wide failing checks drop by exactly one, so no other module is affected.

## Not applied to `meshstack/payment-method`

Its `buildingblock/` runs Terraform against the `meshstack` provider, so someone has to provision an API key with permission to create payment methods and wire `MESHSTACK_API_KEY` / `MESHSTACK_API_SECRET` into the runner environment — the same setup other backplane READMEs in this repo document. That is backplane work, so its missing tier stays a real finding rather than something to mute. Its larger gap is the absent `e2e/` directory (Testing 🔴 0%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)